### PR TITLE
docs: update repo URL after rename

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,4 +48,4 @@ sudo darwin-rebuild switch --flake . --override-input nix-home /Users/you/git/ni
 |------|---------|
 | [nix-ai](https://github.com/JacobPEvans/nix-ai) | AI coding tools (Claude, Gemini, Copilot) |
 | **nix-home** (this repo) | Dev environment |
-| [nix-config](https://github.com/JacobPEvans/nix) | macOS system config (consumes both) |
+| [nix-darwin](https://github.com/JacobPEvans/nix-darwin) | macOS system config (consumes both) |

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ sharedModules = [ nix-home.homeManagerModules.default ];
 |------|-------------|
 | [nix-ai](https://github.com/JacobPEvans/nix-ai) | AI coding tools (Claude, Gemini, Copilot) |
 | **nix-home** (you are here) | Dev environment |
-| [nix-config](https://github.com/JacobPEvans/nix-config) | macOS system config (consumes both) |
+| [nix-darwin](https://github.com/JacobPEvans/nix-darwin) | macOS system config (consumes both) |
 
 ## License
 


### PR DESCRIPTION
## Summary
- Update nix-config references to nix-darwin after repo rename

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update repository references from `nix-config` to `nix-darwin` in documentation files after repo rename.
> 
>   - **Documentation**:
>     - Update repository reference from `nix-config` to `nix-darwin` in `CLAUDE.md` and `README.md` after repository rename.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix-home&utm_source=github&utm_medium=referral)<sup> for 308ed81fec5c661f728d055450639d44b9b46cd5. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->