### PR TITLE
feat: release polish — license, workflows, and renovate config

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,16 @@
+name: Auto Merge
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    uses: JacobPEvans/.github/.github/workflows/_auto-merge.yml@main
+    permissions:
+      contents: write
+      pull-requests: write

--- a/.github/workflows/ci-fail-issue.yml
+++ b/.github/workflows/ci-fail-issue.yml
@@ -1,0 +1,20 @@
+name: CI Fail Issue
+
+on:
+  workflow_run:
+    workflows: ["CI Gate"]
+    types: [completed]
+    branches: [main]
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+
+jobs:
+  handle-failure:
+    if: github.event.workflow_run.conclusion == 'failure'
+    uses: JacobPEvans/ai-workflows/.github/workflows/ci-fail-issue.yml@v0.6.0
+    with:
+      workflow_name: "CI Gate"
+    secrets: inherit

--- a/.github/workflows/ci-fix.yml
+++ b/.github/workflows/ci-fix.yml
@@ -1,0 +1,29 @@
+name: CI Fix (Claude)
+
+on:
+  workflow_run:
+    workflows: ["CI Gate"]
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: write
+  id-token: write
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: ci-fix-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+jobs:
+  fix:
+    if: >-
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.head_branch != 'main'
+    uses: JacobPEvans/ai-workflows/.github/workflows/ci-fix.yml@v0.5.1
+    with:
+      repo_context: "Nix home-manager modules for cross-platform dev environment (git, zsh, VS Code, tmux)"
+      ci_structure: "ci-gate.yml (dorny/paths-filter + nix-check + markdown-lint + alls-green gate)"
+      extra_tools: "Bash(nix:*)"
+    secrets: inherit

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,21 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+  issue_comment:
+    types: [created]
+
+permissions:
+  actions: read
+  contents: read
+  id-token: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  review:
+    uses: JacobPEvans/ai-workflows/.github/workflows/claude-review.yml@v0.5.1
+    with:
+      review_prompt: "Focus on Nix flake patterns, home-manager module structure, cross-platform dev environment best practices"
+    secrets: inherit

--- a/.github/workflows/final-pr-review.yml
+++ b/.github/workflows/final-pr-review.yml
@@ -1,0 +1,19 @@
+name: Final PR Review
+
+on:
+  pull_request_review:
+    types: [submitted]
+  check_suite:
+    types: [completed]
+
+permissions:
+  checks: read
+  contents: read
+  id-token: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  review:
+    uses: JacobPEvans/ai-workflows/.github/workflows/final-pr-review.yml@v0.5.1
+    secrets: inherit

--- a/.github/workflows/issue-auto-resolve.yml
+++ b/.github/workflows/issue-auto-resolve.yml
@@ -1,0 +1,72 @@
+name: Issue Auto-Resolve
+
+on:
+  issues:
+    types: [opened]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "Issue number to resolve"
+        required: true
+        type: string
+      skip_triage:
+        description: "Skip triage (labels pre-applied)"
+        type: string
+        default: "false"
+
+permissions:
+  actions: write
+  contents: write
+  id-token: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  dispatch:
+    if: github.event_name == 'issues'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Dispatch as workflow_dispatch
+        env:
+          GH_TOKEN: ${{ github.token }}
+          WORKFLOW_NAME: ${{ github.workflow }}
+          ISSUE_NUM: ${{ github.event.issue.number }}
+          IS_BOT: ${{ github.event.sender.type == 'Bot' }}
+          HAS_AI_LABEL: ${{ contains(github.event.issue.labels.*.name, 'ai:created') }}
+        run: |
+          if [[ "$IS_BOT" == "true" && "$HAS_AI_LABEL" != "true" ]]; then
+            echo "Bot issue without ai:created label — skipping"
+            exit 0
+          fi
+          SKIP="false"
+          if [[ "$IS_BOT" == "true" ]]; then
+            SKIP="true"
+          fi
+          gh workflow run "$WORKFLOW_NAME" \
+            --repo "$GITHUB_REPOSITORY" \
+            -f issue_number="$ISSUE_NUM" \
+            -f skip_triage="$SKIP"
+
+  run-triage:
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      inputs.skip_triage != 'true'
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-triage.yml@v0.5.1
+    secrets: inherit
+    with:
+      issue_number: ${{ inputs.issue_number }}
+
+  resolve-issue:
+    needs: [run-triage]
+    if: >-
+      always() &&
+      github.event_name == 'workflow_dispatch' &&
+      (needs.run-triage.result == 'success' || needs.run-triage.result == 'skipped')
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@v0.5.1
+    secrets: inherit
+    with:
+      repo_context: "Nix home-manager modules for cross-platform dev environment (git, zsh, VS Code, tmux)"
+      extra_tools: "Bash(nix:*)"
+      issue_number: ${{ inputs.issue_number }}

--- a/.github/workflows/post-merge-docs-review.yml
+++ b/.github/workflows/post-merge-docs-review.yml
@@ -1,0 +1,41 @@
+name: Post-Merge Docs Review
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: 'Commit SHA to review'
+        required: false
+        type: string
+
+permissions:
+  actions: write
+  contents: write
+  id-token: write
+  pull-requests: write
+
+jobs:
+  dispatch:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Re-trigger as workflow_dispatch
+        env:
+          WORKFLOW_NAME: ${{ github.workflow }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run "$WORKFLOW_NAME" \
+            --repo "${{ github.repository }}" \
+            --ref main \
+            -f commit_sha="${{ github.sha }}"
+
+  review:
+    if: github.event_name == 'workflow_dispatch'
+    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-docs-review.yml@v0.5.1
+    with:
+      commit_sha: ${{ inputs.commit_sha || github.sha }}
+    secrets: inherit

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -1,0 +1,41 @@
+name: Post-Merge Test Review
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: 'Commit SHA to review'
+        required: false
+        type: string
+
+permissions:
+  actions: write
+  contents: write
+  id-token: write
+  pull-requests: write
+
+jobs:
+  dispatch:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Re-trigger as workflow_dispatch
+        env:
+          WORKFLOW_NAME: ${{ github.workflow }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run "$WORKFLOW_NAME" \
+            --repo "${{ github.repository }}" \
+            --ref main \
+            -f commit_sha="${{ github.sha }}"
+
+  review:
+    if: github.event_name == 'workflow_dispatch'
+    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-tests.yml@v0.5.1
+    with:
+      commit_sha: ${{ inputs.commit_sha || github.sha }}
+    secrets: inherit

--- a/.github/workflows/trigger-nix-update.yml
+++ b/.github/workflows/trigger-nix-update.yml
@@ -1,0 +1,37 @@
+name: Trigger Nix Flake Update
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  trigger-nix:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Trigger nix-darwin flake update
+        run: |
+          gh api repos/JacobPEvans/nix-darwin/dispatches \
+            --method POST \
+            --field event_type='upstream-repo-updated' \
+            --field client_payload[flake_input_name]='nix-home' \
+            --field client_payload[source_repo]="$SOURCE_REPO" \
+            --field client_payload[source_ref]="$SOURCE_REF" \
+            --field client_payload[commit_sha]="$COMMIT_SHA"
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT_WORKFLOW_DISPATCH }}
+          SOURCE_REPO: ${{ github.repository }}
+          SOURCE_REF: ${{ github.ref }}
+          COMMIT_SHA: ${{ github.sha }}
+
+      - name: Log dispatch
+        env:
+          SOURCE_REPO: ${{ github.repository }}
+          COMMIT_SHA: ${{ github.sha }}
+        run: |
+          echo "Triggered nix-darwin flake update workflow"
+          echo "Source: $SOURCE_REPO"
+          echo "Commit: $COMMIT_SHA"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Jacob P. Evans
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "local>JacobPEvans/.github:renovate-presets"
+  ]
+}


### PR DESCRIPTION
## Summary

- Add MIT license (2025, Jacob P. Evans)
- Add Renovate configuration extending shared presets from JacobPEvans/.github
- Add trigger-nix-update workflow to notify nix-darwin on main pushes
- Add auto-merge workflow using shared reusable workflow
- Add AI workflow callers: claude-review, issue-auto-resolve, ci-fix, ci-fail-issue, final-pr-review, post-merge-docs-review, post-merge-tests

## Test plan

- [ ] Verify CI Gate passes on this PR
- [ ] Confirm Renovate picks up the config after merge
- [ ] Verify trigger-nix-update dispatches correctly on next main push
- [ ] Confirm AI workflows (claude-review, ci-fix, etc.) trigger on appropriate events

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add MIT license, Renovate config, and multiple GitHub workflows for automation and maintenance.
> 
>   - **License**:
>     - Add MIT license for 2025 under Jacob P. Evans.
>   - **Renovate Configuration**:
>     - Add `renovate.json` extending shared presets from `JacobPEvans/.github`.
>   - **Workflows**:
>     - Add `auto-merge.yml` for auto-merging PRs using a shared workflow.
>     - Add `trigger-nix-update.yml` to notify nix-darwin on main branch pushes.
>     - Add AI workflow callers: `claude-review.yml`, `issue-auto-resolve.yml`, `ci-fix.yml`, `ci-fail-issue.yml`, `final-pr-review.yml`, `post-merge-docs-review.yml`, `post-merge-tests.yml` for various automation tasks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix-home&utm_source=github&utm_medium=referral)<sup> for 700b95cf7c656f2d7b7f927308fa4966f2afb883. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->