### PR TITLE
fix: resolve module-eval CI check failures

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -47,7 +47,7 @@
           pkgs = nixpkgs.legacyPackages.${system};
         in
         import ./lib/checks.nix {
-          inherit pkgs home-manager;
+          inherit pkgs nixpkgs home-manager;
           src = ./.;
           homeModule = self.homeManagerModules.default;
         }

--- a/modules/home-manager/linters/markdownlint.nix
+++ b/modules/home-manager/linters/markdownlint.nix
@@ -14,12 +14,12 @@
 # - gitignore: true (respect .gitignore patterns)
 #
 # Usage:
-#   markdownlint-cli2 --config ~/.markdownlint-cli2.yaml <file>
+#   markdownlint-cli2 --config ~/.markdownlint-cli2.jsonc <file>
 #   pre-commit run markdownlint-cli2 --all-files
 
 { config, ... }:
 
 {
-  # ~/.markdownlint-cli2.yaml - Markdownlint configuration
-  ".markdownlint-cli2.yaml".source = ../../../.markdownlint-cli2.yaml;
+  # ~/.markdownlint-cli2.jsonc - Markdownlint configuration (JSONC format)
+  ".markdownlint-cli2.jsonc".source = ../../../.markdownlint-cli2.jsonc;
 }


### PR DESCRIPTION
## Summary

- Fixes three bugs in the `module-eval` check introduced by PR #20 that caused `Nix Check` CI failures
- The `Merge Gate` was failing as a downstream consequence of the `Nix Check` failure

## Root Causes Fixed

**1. `userConfig` missing in `module-eval`**
`common.nix` uses `userConfig` as a module function argument. When home-manager evaluates the module, the `?` default-value syntax is bypassed — home-manager uses `_module.args` lookup instead. Fix: pass `userConfig` via `extraSpecialArgs` in `homeManagerConfiguration`.

**2. VSCode unfree license error in `module-eval`**
The test `pkgs` instance (from `nixpkgs.legacyPackages`) does not allow unfree packages. The module enables VSCode (unfree), causing evaluation to fail. Fix: create a `pkgsWithUnfree` instance with `config.allowUnfree = true` for the check. Accepts `nixpkgs` as a new argument in `checks.nix` to support this.

**3. Stale `.markdownlint-cli2.yaml` reference in `markdownlint.nix`**
PR #20 removed `.markdownlint-cli2.yaml` (YAML) in favour of `.markdownlint-cli2.jsonc` (JSONC), but `markdownlint.nix` still referenced the deleted YAML path. Fix: update the source path and destination filename to reference the `.jsonc` file.

## Validation

`nix flake check --all-systems` passes locally with all fixes applied.

## Test plan

- [ ] `Nix Check` CI job passes on this PR
- [ ] `Merge Gate` CI job passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix `module-eval` CI check failures by passing `userConfig`, allowing unfree packages, and updating `markdownlint` reference.
> 
>   - **Behavior**:
>     - Fix `module-eval` check by passing `userConfig` via `extraSpecialArgs` in `homeManagerConfiguration` in `checks.nix`.
>     - Create `pkgsWithUnfree` in `checks.nix` to allow unfree packages for VSCode.
>     - Update `markdownlint.nix` to reference `.markdownlint-cli2.jsonc` instead of removed `.yaml` file.
>   - **Validation**:
>     - `nix flake check --all-systems` passes locally with fixes.
>   - **Test Plan**:
>     - Ensure `Nix Check` and `Merge Gate` CI jobs pass on this PR.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix-home&utm_source=github&utm_medium=referral)<sup> for c71190df389a9e1c43f7a72f4255202bc5d07b7e. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->