### PR TITLE
fix: bump ci-fail-issue workflow to v0.6.1

### DIFF
--- a/.github/workflows/ci-fail-issue.yml
+++ b/.github/workflows/ci-fail-issue.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   handle-failure:
     if: github.event.workflow_run.conclusion == 'failure'
-    uses: JacobPEvans/ai-workflows/.github/workflows/ci-fail-issue.yml@v0.6.0
+    uses: JacobPEvans/ai-workflows/.github/workflows/ci-fail-issue.yml@v0.6.1
     with:
       workflow_name: "CI Gate"
     secrets: inherit


### PR DESCRIPTION
Bumps the ci-fail-issue.yml workflow reference from @v0.6.0 to @v0.6.1.

The v0.6.1 rollout replaced @v0.5.1 refs but missed this file which was already at @v0.6.0.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Bumps `ci-fail-issue.yml` workflow reference from `@v0.6.0` to `@v0.6.1`.
> 
>   - **Workflow Update**:
>     - Bumps `ci-fail-issue.yml` workflow reference from `@v0.6.0` to `@v0.6.1` to ensure the latest version is used.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix-home&utm_source=github&utm_medium=referral)<sup> for 56bf266da1e41d2a353097de9c85305bdbbd04b7. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->