### PR TITLE
chore: bump ai-workflows to v0.7.0

### DIFF
--- a/.github/workflows/ci-fail-issue.yml
+++ b/.github/workflows/ci-fail-issue.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   handle-failure:
     if: github.event.workflow_run.conclusion == 'failure'
-    uses: JacobPEvans/ai-workflows/.github/workflows/ci-fail-issue.yml@v0.6.1
+    uses: JacobPEvans/ai-workflows/.github/workflows/ci-fail-issue.yml@v0.7.0
     with:
       workflow_name: "CI Gate"
     secrets: inherit

--- a/.github/workflows/ci-fix.yml
+++ b/.github/workflows/ci-fix.yml
@@ -21,7 +21,7 @@ jobs:
     if: >-
       github.event.workflow_run.conclusion == 'failure' &&
       github.event.workflow_run.head_branch != 'main'
-    uses: JacobPEvans/ai-workflows/.github/workflows/ci-fix.yml@v0.6.1
+    uses: JacobPEvans/ai-workflows/.github/workflows/ci-fix.yml@v0.7.0
     with:
       repo_context: "Nix home-manager modules for cross-platform dev environment (git, zsh, VS Code, tmux)"
       ci_structure: "ci-gate.yml (dorny/paths-filter + nix-check + markdown-lint + alls-green gate)"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   review:
-    uses: JacobPEvans/ai-workflows/.github/workflows/claude-review.yml@v0.6.1
+    uses: JacobPEvans/ai-workflows/.github/workflows/claude-review.yml@v0.7.0
     with:
       review_prompt: "Focus on Nix flake patterns, home-manager module structure, cross-platform dev environment best practices"
     secrets: inherit

--- a/.github/workflows/final-pr-review.yml
+++ b/.github/workflows/final-pr-review.yml
@@ -15,5 +15,5 @@ permissions:
 
 jobs:
   review:
-    uses: JacobPEvans/ai-workflows/.github/workflows/final-pr-review.yml@v0.6.1
+    uses: JacobPEvans/ai-workflows/.github/workflows/final-pr-review.yml@v0.7.0
     secrets: inherit

--- a/.github/workflows/issue-auto-resolve.yml
+++ b/.github/workflows/issue-auto-resolve.yml
@@ -64,7 +64,7 @@ jobs:
 
   run-triage:
     if: github.event_name == 'workflow_dispatch'
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-triage.yml@v0.6.1
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-triage.yml@v0.7.0
     secrets: inherit
     with:
       issue_number: ${{ inputs.issue_number }}
@@ -75,7 +75,7 @@ jobs:
       always() &&
       github.event_name == 'workflow_dispatch' &&
       (needs.run-triage.result == 'success' || needs.run-triage.result == 'skipped')
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@v0.6.1
+    uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@v0.7.0
     secrets: inherit
     with:
       repo_context: "Nix home-manager dev environment configuration"

--- a/.github/workflows/post-merge-docs-review.yml
+++ b/.github/workflows/post-merge-docs-review.yml
@@ -35,7 +35,7 @@ jobs:
 
   review:
     if: github.event_name == 'workflow_dispatch'
-    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-docs-review.yml@v0.6.1
+    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-docs-review.yml@v0.7.0
     with:
       commit_sha: ${{ inputs.commit_sha || github.sha }}
     secrets: inherit

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -35,7 +35,7 @@ jobs:
 
   review:
     if: github.event_name == 'workflow_dispatch'
-    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-tests.yml@v0.6.1
+    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-tests.yml@v0.7.0
     with:
       commit_sha: ${{ inputs.commit_sha || github.sha }}
     secrets: inherit


### PR DESCRIPTION
Dependency bot workflows (renovate, dependabot) will now show as skipped instead of failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Bump `ai-workflows` version to v0.7.0 in multiple GitHub Actions workflows to improve dependency bot handling.
> 
>   - **Workflows Updated**:
>     - Bump `ai-workflows` version from v0.6.1 to v0.7.0 in `.github/workflows/ci-fail-issue.yml`, `.github/workflows/ci-fix.yml`, and `.github/workflows/claude-review.yml`.
>     - Update `ai-workflows` version in `.github/workflows/final-pr-review.yml`, `.github/workflows/issue-auto-resolve.yml`, and `.github/workflows/post-merge-docs-review.yml`.
>     - Change `ai-workflows` version in `.github/workflows/post-merge-tests.yml`.
>   - **Behavior**:
>     - Dependency bot workflows (renovate, dependabot) will now show as skipped instead of failed.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fnix-home&utm_source=github&utm_medium=referral)<sup> for 305124b97494d9b194e705f4c8fb2c2c3b9948a6. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->