### PR TITLE
fix: correct best-practices permissions and add concurrency

### DIFF
--- a/.github/workflows/best-practices.yml
+++ b/.github/workflows/best-practices.yml
@@ -1,12 +1,20 @@
 name: Best Practices
+
 on:
   schedule:
     - cron: "0 3 * * 2,5"
   workflow_dispatch:
+
 permissions:
   contents: read
   id-token: write
-  pull-requests: write
+  issues: write
+  pull-requests: read
+
+concurrency:
+  group: best-practices-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   best-practices:
     uses: JacobPEvans/ai-workflows/.github/workflows/best-practices.yml@v0.8.0

--- a/.github/workflows/code-simplifier.yml
+++ b/.github/workflows/code-simplifier.yml
@@ -9,7 +9,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: code-simplifier
+  group: code-simplifier-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/next-steps.yml
+++ b/.github/workflows/next-steps.yml
@@ -10,7 +10,7 @@ permissions:
   issues: write
 
 concurrency:
-  group: next-steps
+  group: next-steps-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -23,6 +23,11 @@ rules:
       - post-merge-tests.yml
       - release-please.yml
       - trigger-nix-update.yml
+      - best-practices.yml
+      - code-simplifier.yml
+      - issue-hygiene.yml
+      - issue-sweeper.yml
+      - next-steps.yml
 
   # IGNORED: workflow_run triggers are used intentionally for post-CI workflows
   # These workflows only read artifacts and open issues/PRs — they do not execute
@@ -54,3 +59,8 @@ rules:
       - issue-auto-resolve.yml
       - post-merge-docs-review.yml
       - post-merge-tests.yml
+      - best-practices.yml
+      - code-simplifier.yml
+      - issue-hygiene.yml
+      - issue-sweeper.yml
+      - next-steps.yml


### PR DESCRIPTION
## Summary
- Fix permissions: add `issues: write`, change `pull-requests` from `write` to `read` (reusable workflow creates issues, not PRs)
- Add concurrency group scoped by ref to prevent cross-branch cancellation
- Scope code-simplifier and next-steps concurrency groups by `${{ github.ref }}`
- Update zizmor config with new workflow file ignore entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)