### PR TITLE
ci: route Nix Validate to RunsOn self-hosted runner

### DIFF
--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -76,7 +76,10 @@ jobs:
     if: needs.changes.outputs.nix == 'true'
     uses: JacobPEvans/.github/.github/workflows/_nix-validate.yml@main
     with:
-      runner_label: "runs-on=${{ github.run_id }}/runner=2cpu-linux-x64"
+      # Only route same-repo PRs to the self-hosted RunsOn runner. Fork PRs
+      # fall back to ubuntu-latest so untrusted code from forks never lands
+      # on a runner with AWS credentials in scope.
+      runner_label: ${{ github.event.pull_request.head.repo.full_name == github.repository && format('runs-on={0}/runner=2cpu-linux-x64', github.run_id) || 'ubuntu-latest' }}
 
   markdown-lint:
     name: Markdown Lint

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -75,6 +75,8 @@ jobs:
     needs: changes
     if: needs.changes.outputs.nix == 'true'
     uses: JacobPEvans/.github/.github/workflows/_nix-validate.yml@main
+    with:
+      runner_label: "runs-on=${{ github.run_id }}/runner=2cpu-linux-x64"
 
   markdown-lint:
     name: Markdown Lint

--- a/flake.nix
+++ b/flake.nix
@@ -1,4 +1,7 @@
 {
+  # Nix Validate runs via the reusable _nix-validate.yml workflow.
+  # As of #135 this repo opts into the RunsOn self-hosted runner via the
+  # runner_label input — see .github/workflows/ci-gate.yml.
   description = "Cross-platform home-manager modules (Nix flake)";
 
   inputs = {


### PR DESCRIPTION
## Summary

- Passes the new `runner_label` input to the reusable `_nix-validate.yml` workflow so `nix flake check` runs on a RunsOn self-hosted spot runner (2 cpu, Linux, x64) instead of `ubuntu-latest`
- nix-home is the first opt-in consumer of the terraform-runs-on RunsOn deployment

## Why

- terraform-runs-on RunsOn deployment is live and validated end-to-end (smoke run completed in <60s on m8i.large spot)
- nix-home is the lowest-risk first consumer: zero macOS-specific jobs, all CI is Linux
- The reusable workflow change in JacobPEvans/.github#158 (merged) added the input with `ubuntu-latest` default, so other consumers (nix-darwin, nix-ai) are unaffected

## Test plan

- [ ] Wait for CI on this PR
- [ ] Confirm the Nix Validate job picks up on a RunsOn spot instance (not ubuntu-latest)
- [ ] Confirm nix flake check succeeds end-to-end
- [ ] Compare wall time vs the previous ubuntu-latest run on main
- [ ] Verify other jobs (Markdown Lint, File Size, Merge Gate) continue running on ubuntu-latest