### PR TITLE
feat: add minio-client (mc) to common packages

### DIFF
--- a/modules/common/packages.nix
+++ b/modules/common/packages.nix
@@ -114,6 +114,7 @@ with pkgs;
   gmailctl # Declarative Gmail filter management via Jsonnet (apply/diff/test)
   rclone # Cloud storage sync — Google Drive, S3, and 70+ backends
   gdrive3 # Google Drive CLI — upload, download, list, share, sync
+  minio-client # MinIO/S3 client (mc) — upload, download, manage objects + bucket policies
 
   # ==========================================================================
   # HTTP & API Tools


### PR DESCRIPTION
## Summary

- Add `minio-client` (mc CLI) to common packages

## Changes

- `modules/common/packages.nix` — add `minio-client` under "Google Workspace CLI Tools" section (sits with other cloud storage CLIs `rclone` and `gdrive3`)

## Why

Needed to upload Splunk add-on artifacts to the homelab MinIO instance (LXC VMID 107, see `ansible-proxmox-apps` `minio` role) and manage bucket policies, versioning, and object tags. This is a permanent dev tool addition rather than an ad-hoc brew install.

## Test plan

- [x] `nixfmt-rfc-style`, `statix`, `deadnix` pass (pre-commit)
- [ ] `nix flake check` passes
- [ ] After merge, `sudo darwin-rebuild switch --flake ~/git/nix-darwin/main` activates and `mc --version` resolves

## Related

- Related: JacobPEvans/ansible-proxmox-apps#158 (MinIO role)
- Related: JacobPEvans/terraform-proxmox#216 (MinIO LXC container)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
