### PR TITLE
refactor: move minio-client to dedicated Object Storage section

### DIFF
--- a/modules/common/packages.nix
+++ b/modules/common/packages.nix
@@ -114,6 +114,12 @@ with pkgs;
   gmailctl # Declarative Gmail filter management via Jsonnet (apply/diff/test)
   rclone # Cloud storage sync — Google Drive, S3, and 70+ backends
   gdrive3 # Google Drive CLI — upload, download, list, share, sync
+
+  # ==========================================================================
+  # Object Storage CLIs
+  # ==========================================================================
+  # S3-compatible object storage clients for upload, download, and bucket management.
+
   minio-client # MinIO/S3 client (mc) — upload, download, manage objects + bucket policies
 
   # ==========================================================================


### PR DESCRIPTION
## Summary

Follow-up to #136. The review on that PR correctly noted that \`minio-client\` was misplaced under "Google Workspace CLI Tools". The fix commit was pushed after the squash-merge had landed, so it ended up stranded. This PR applies the reorganization cleanly on top of current main.

## Changes

- Move \`minio-client\` out of the "Google Workspace CLI Tools" section
- Create a new dedicated "Object Storage CLIs" section
- Leaves room to add other S3-compatible clients (s3cmd, aws-cli, etc.) alongside

## Test plan

- [x] \`nixfmt-rfc-style\`, \`statix\`, \`deadnix\` pass
- [ ] \`nix flake check\` passes
- [ ] \`sudo darwin-rebuild switch\` activates without issue

## Related

- Related: JacobPEvans/nix-home#136 — original addition (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)