### PR TITLE
feat: add aws-vault to common packages

### DIFF
--- a/modules/common/packages.nix
+++ b/modules/common/packages.nix
@@ -99,6 +99,7 @@ with pkgs;
   bitwarden-cli # CLI for Bitwarden password manager (bw command)
   bws # Bitwarden Secrets Manager CLI (for machine secrets)
   doppler # Doppler secrets manager CLI (for CI/CD and team secrets)
+  aws-vault # AWS credential management — session credentials backed by macOS Keychain (used by av/avl/avd/ava/avr aliases)
 
   # ==========================================================================
   # Remote Shell

--- a/modules/common/packages.nix
+++ b/modules/common/packages.nix
@@ -99,7 +99,7 @@ with pkgs;
   bitwarden-cli # CLI for Bitwarden password manager (bw command)
   bws # Bitwarden Secrets Manager CLI (for machine secrets)
   doppler # Doppler secrets manager CLI (for CI/CD and team secrets)
-  aws-vault # AWS credential management — session credentials backed by macOS Keychain (used by av/avl/avd/ava/avr aliases)
+  aws-vault # AWS credential management — session credentials backed by the OS keychain/credential store (used by av/avl/avd/ava/avr aliases)
 
   # ==========================================================================
   # Remote Shell


### PR DESCRIPTION
## Summary

Adds `aws-vault` to `home.packages` so it's permanently available in the interactive shell — not only inside direnv-activated devshells.

## Why

`aws-vault` was only declared in `nix-devenv/shells/aws/default.nix`, which means it was only reachable inside a terraform-shell worktree. But the rest of the repo already assumed it was in PATH:

- `CLAUDE.md` line 28 explicitly lists _"Security tools (password manager CLIs, aws-vault)"_ as belonging in nix-home
- `modules/home-manager/aws/config.nix` line 6 documents that credentials should use aws-vault (macOS Keychain-backed), never `~/.aws/credentials`
- `modules/home-manager/zsh/aliases.nix` lines 60-74 define `av`, `avl`, `avd`, `ava`, `avr` aliases that fail silently without aws-vault in PATH
- `~/Library/Keychains/aws-vault.keychain-db` already has working credentials for `terraform`, `default`, and `iam-user` profiles

## Changes

- `modules/common/packages.nix` — add `aws-vault` to the "Security & Credential Management" section alongside `bitwarden-cli`, `bws`, `doppler`

## Deferred cleanup (not in this PR)

`aws-vault` can eventually be removed from `nix-devenv/shells/aws/default.nix` since home-manager will now provide it on every PATH. Leave it there for now to avoid breaking any CI/runner context that doesn't activate home-manager.

## Test plan

- [x] `nixfmt-rfc-style`, `statix`, `deadnix`, pre-commit hooks pass
- [ ] `nix flake check` passes
- [ ] After `sudo darwin-rebuild switch`, `which aws-vault` resolves in a fresh shell (no direnv)
- [ ] `aws-vault list` shows existing profiles (`default`, `terraform`, `iam-user`)

## Related

- Related: #136 — `minio-client` addition
- Related: #138 — Object Storage CLIs section refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)