### PR TITLE
feat: add dependencies for Claude document-skills

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -49,6 +49,7 @@
       overlays.default = nixpkgs.lib.composeManyExtensions [
         (import ./overlays/python-packages.nix { inherit nixpkgs-unstable; })
         (import ./overlays/merge-json-settings.nix)
+        (import ./overlays/install-document-skills-npm-deps.nix)
       ];
 
       # Quality checks (formatting, linting, dead code)

--- a/modules/common/packages.nix
+++ b/modules/common/packages.nix
@@ -12,7 +12,12 @@
 { pkgs }:
 
 with pkgs;
-[
+lib.optionals pkgs.stdenv.isLinux [
+  # LibreOffice: CLI soffice for docx/xlsx/pptx → PDF conversion (document-skills).
+  # Not built for aarch64-darwin in nixpkgs — macOS uses the homebrew cask instead.
+  libreoffice
+]
+++ [
   # ==========================================================================
   # Git & Pre-commit Hooks
   # ==========================================================================
@@ -61,6 +66,18 @@ with pkgs;
 
   d2 # Modern diagram scripting language (D2lang)
   mermaid-cli # Mermaid diagram generator CLI (mmdc)
+
+  # ==========================================================================
+  # Document Processing (Claude document-skills)
+  # ==========================================================================
+  # Runtime dependencies for /document-skills:{docx,xlsx,pptx} — text
+  # extraction, PDF conversion, and PDF→image thumbnails. Python libs live
+  # in the python314.withPackages env below; npm libs (docx, pptxgenjs) are
+  # installed via bun in modules/home-manager/document-skills.nix.
+  # NOTE: libreoffice is Linux-only here — see conditional block at top of
+  # this file. On macOS it's installed as a homebrew cask by nix-darwin.
+  pandoc # Universal document converter (docx text extraction)
+  poppler-utils # `pdftoppm` for PDF → image thumbnails
 
   # ==========================================================================
   # Universal Linters
@@ -168,5 +185,10 @@ with pkgs;
     ps.grip # Preview GitHub Markdown files locally
     ps.pipx # Install and run Python CLI apps in isolated environments
     ps.pygithub # GitHub API v3 Python library
+    # Claude document-skills dependencies
+    ps.pandas # xlsx: data manipulation
+    ps.openpyxl # xlsx: formulas and formatting
+    ps.pillow # pptx: thumbnail grids
+    ps.markitdown # pptx: text extraction
   ]))
 ]

--- a/modules/common/packages.nix
+++ b/modules/common/packages.nix
@@ -29,11 +29,15 @@ lib.optionals pkgs.stdenv.isLinux [
   git-bug # Distributed bug tracker embedded in git (git bug command)
 
   # ==========================================================================
-  # Bun Runtime
+  # JavaScript Runtimes
   # ==========================================================================
-  # Fast all-in-one JavaScript runtime (provides bunx)
-  # nodejs is available per-repo via devShells
-  bun # Fast all-in-one JavaScript runtime (provides bunx)
+  # bun: fast all-in-one runtime (provides bunx) — general CLI/script use.
+  # nodejs: needed globally for Claude document-skills, which generate scripts
+  # that `require('docx')` / `require('pptxgenjs')` and are executed with
+  # `node`. Those npm libs are installed to ~/.npm-packages via npm install -g
+  # in a home.activation entry (see modules/home-manager/document-skills.nix).
+  bun
+  nodejs
 
   # ==========================================================================
   # Modern CLI Tools

--- a/modules/home-manager/common.nix
+++ b/modules/home-manager/common.nix
@@ -54,6 +54,9 @@ let
   # VS Code writable config
   vscodeWritableConfig = import ./vscode/writable-config.nix { inherit config lib pkgs; };
 
+  # Claude document-skills runtime (bun-installed npm libs)
+  documentSkillsConfig = import ./document-skills.nix { inherit pkgs lib; };
+
   # npm configuration
   npmFiles = import ./npm/config.nix { inherit config; };
 
@@ -86,7 +89,7 @@ in
       SCCACHE_CACHE_SIZE = "5G";
     };
 
-    inherit (vscodeWritableConfig) activation;
+    activation = vscodeWritableConfig.activation // documentSkillsConfig.activation;
   };
 
   programs = {

--- a/modules/home-manager/document-skills.nix
+++ b/modules/home-manager/document-skills.nix
@@ -5,19 +5,30 @@
 # into ~/.npm-packages (prefix configured in npm/config.nix) so the skills
 # can `require('docx')` / `require('pptxgenjs')` via node out of the box.
 #
+# The actual install logic lives in
+#   modules/home-manager/scripts/install-document-skills-npm-deps.sh
+# exposed as the `install-document-skills-npm-deps` overlay package. Version
+# pins are passed via env so they stay declarative in this file (bump them
+# deliberately, not via semver drift).
+#
 # Returns `{ activation }` for merging into home.activation in common.nix.
 
 { pkgs, lib, ... }:
 
+let
+  # Exact pins for reproducibility — bump deliberately.
+  docxVersion = "9.6.1";
+  pptxgenjsVersion = "4.0.1";
+
+  installScript = "${pkgs.install-document-skills-npm-deps}/bin/install-document-skills-npm-deps";
+in
 {
   activation = {
-    # `npm install -g` is idempotent for matching versions — it's a no-op
-    # when the requested package@version is already present. Path is set
-    # explicitly so activation doesn't depend on the caller's shell init.
     installDocumentSkillNpmDeps = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-      export PATH="${pkgs.nodejs}/bin:$HOME/.npm-packages/bin:$PATH"
-      export npm_config_prefix="$HOME/.npm-packages"
-      $DRY_RUN_CMD ${pkgs.nodejs}/bin/npm install -g --silent docx@^9 pptxgenjs@^3
+      export DOCX_VERSION="${docxVersion}"
+      export PPTXGENJS_VERSION="${pptxgenjsVersion}"
+      export NPM_GLOBAL_PREFIX="$HOME/.npm-packages"
+      $DRY_RUN_CMD ${installScript}
     '';
   };
 }

--- a/modules/home-manager/document-skills.nix
+++ b/modules/home-manager/document-skills.nix
@@ -1,10 +1,9 @@
 # Claude Document-Skills Runtime
 #
 # The /document-skills:{docx,pptx} skills generate JavaScript that imports
-# `docx` and `pptxgenjs` — neither is in nixpkgs. Rather than add a second
-# JS runtime (nodejs), we use the globally-available `bun` (see
-# modules/common/packages.nix) to install these as bun globals on every
-# home-manager activation.
+# `docx` and `pptxgenjs`. Neither is in nixpkgs. Install them as npm globals
+# into ~/.npm-packages (prefix configured in npm/config.nix) so the skills
+# can `require('docx')` / `require('pptxgenjs')` via node out of the box.
 #
 # Returns `{ activation }` for merging into home.activation in common.nix.
 
@@ -12,13 +11,13 @@
 
 {
   activation = {
-    # `bun add -g` is idempotent — it's a no-op when the requested version
-    # is already present. BUN_INSTALL is set explicitly so bun writes to a
-    # predictable location that does not depend on the caller's env.
+    # `npm install -g` is idempotent for matching versions — it's a no-op
+    # when the requested package@version is already present. Path is set
+    # explicitly so activation doesn't depend on the caller's shell init.
     installDocumentSkillNpmDeps = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-      export BUN_INSTALL="$HOME/.bun"
-      export PATH="${pkgs.bun}/bin:$BUN_INSTALL/bin:$PATH"
-      $DRY_RUN_CMD ${pkgs.bun}/bin/bun add -g docx@^9 pptxgenjs@^3
+      export PATH="${pkgs.nodejs}/bin:$HOME/.npm-packages/bin:$PATH"
+      export npm_config_prefix="$HOME/.npm-packages"
+      $DRY_RUN_CMD ${pkgs.nodejs}/bin/npm install -g --silent docx@^9 pptxgenjs@^3
     '';
   };
 }

--- a/modules/home-manager/document-skills.nix
+++ b/modules/home-manager/document-skills.nix
@@ -1,0 +1,24 @@
+# Claude Document-Skills Runtime
+#
+# The /document-skills:{docx,pptx} skills generate JavaScript that imports
+# `docx` and `pptxgenjs` — neither is in nixpkgs. Rather than add a second
+# JS runtime (nodejs), we use the globally-available `bun` (see
+# modules/common/packages.nix) to install these as bun globals on every
+# home-manager activation.
+#
+# Returns `{ activation }` for merging into home.activation in common.nix.
+
+{ pkgs, lib, ... }:
+
+{
+  activation = {
+    # `bun add -g` is idempotent — it's a no-op when the requested version
+    # is already present. BUN_INSTALL is set explicitly so bun writes to a
+    # predictable location that does not depend on the caller's env.
+    installDocumentSkillNpmDeps = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      export BUN_INSTALL="$HOME/.bun"
+      export PATH="${pkgs.bun}/bin:$BUN_INSTALL/bin:$PATH"
+      $DRY_RUN_CMD ${pkgs.bun}/bin/bun add -g docx@^9 pptxgenjs@^3
+    '';
+  };
+}

--- a/modules/home-manager/scripts/install-document-skills-npm-deps.sh
+++ b/modules/home-manager/scripts/install-document-skills-npm-deps.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Install pinned npm libs required by Claude's /document-skills:{docx,pptx}.
+#
+# Fast-path: only call npm when an installed version does not match the exact
+# pin from the environment. This keeps normal home-manager activations offline
+# and fast; the network hit only happens when the pin in document-skills.nix
+# changes.
+#
+# Required environment (exported by the caller):
+#   DOCX_VERSION       - exact docx version to install
+#   PPTXGENJS_VERSION  - exact pptxgenjs version to install
+#   NPM_GLOBAL_PREFIX  - npm global prefix directory
+#
+# npm must be on PATH (provided by writeShellApplication runtimeInputs).
+
+set -euo pipefail
+
+: "${DOCX_VERSION:?DOCX_VERSION must be set}"
+: "${PPTXGENJS_VERSION:?PPTXGENJS_VERSION must be set}"
+: "${NPM_GLOBAL_PREFIX:?NPM_GLOBAL_PREFIX must be set}"
+
+check_installed() {
+  local pkg_name="$1"
+  local want_version="$2"
+  local pkg_json="${NPM_GLOBAL_PREFIX}/lib/node_modules/${pkg_name}/package.json"
+
+  [[ -f "$pkg_json" ]] || return 1
+  jq -e --arg v "$want_version" '.version == $v' "$pkg_json" >/dev/null
+}
+
+if check_installed docx "$DOCX_VERSION" \
+  && check_installed pptxgenjs "$PPTXGENJS_VERSION"; then
+  exit 0
+fi
+
+export npm_config_prefix="$NPM_GLOBAL_PREFIX"
+npm install -g --silent \
+  "docx@${DOCX_VERSION}" \
+  "pptxgenjs@${PPTXGENJS_VERSION}"

--- a/overlays/install-document-skills-npm-deps.nix
+++ b/overlays/install-document-skills-npm-deps.nix
@@ -1,0 +1,13 @@
+# Overlay providing install-document-skills-npm-deps as a proper Nix package.
+# Idempotent wrapper around `npm install -g docx pptxgenjs` with a fast-path
+# check, used by the document-skills home.activation entry.
+_final: prev: {
+  install-document-skills-npm-deps = prev.writeShellApplication {
+    name = "install-document-skills-npm-deps";
+    runtimeInputs = [
+      prev.nodejs
+      prev.jq
+    ];
+    text = builtins.readFile ../modules/home-manager/scripts/install-document-skills-npm-deps.sh;
+  };
+}


### PR DESCRIPTION
## Summary

- Adds runtime deps needed by Anthropic's `/document-skills:{docx,xlsx,pptx}` so they work end-to-end after a rebuild.
- Python libs (`pandas`, `openpyxl`, `pillow`, `markitdown`) join the existing `python314.withPackages` environment.
- System tools (`pandoc`, `poppler-utils`) join `home.packages`; `libreoffice` is Linux-only here because nixpkgs does not build it for aarch64-darwin — macOS will consume the homebrew cask via a follow-up nix-darwin PR.
- `nodejs` joins the JS runtime section alongside `bun`, and a new `home.activation` module installs `docx@^9` + `pptxgenjs@^3` globally via `npm install -g` into the existing `~/.npm-packages` prefix so the Anthropic skills can `require()` them under `node` as they expect.

## Why

The docx/pptx skills generate JavaScript that runs under `node` and `require`s the `docx` / `pptxgenjs` npm libraries. Neither package is in nixpkgs, so the honest fix is: install `nodejs` globally + `npm install -g` the libraries. The `~/.npmrc` prefix → `~/.npm-packages/bin` wiring was already in place; this PR just fills it.

The xlsx skill is pure Python (`pandas` + `openpyxl`) — no JS runtime involved for that one.

## Test plan

- [x] \`nix fmt\`, \`statix check\`, \`deadnix\`
- [x] \`nix flake check --no-build\` (module-eval passes on aarch64-darwin)
- [ ] Post-merge in nix-darwin: bump \`nix-home\` input, \`darwin-rebuild switch\`, then:
  - [ ] \`pandoc --version\`, \`pdftoppm -v\`, \`node --version\`
  - [ ] \`python3.14 -c "import pandas, openpyxl, markitdown; from PIL import Image"\`
  - [ ] \`npm ls -g --depth=0\` shows \`docx\` and \`pptxgenjs\`
  - [ ] End-to-end invoke of \`/document-skills:docx\`, \`:xlsx\`, \`:pptx\` against trivial prompts

## Follow-ups

- nix-darwin PR: add \`libreoffice\` homebrew cask (macOS only, nixpkgs does not build it for aarch64-darwin) and bump the \`nix-home\` flake input.