### PR TITLE
feat(packages): audit package placement — remove project-scoped tools from global env

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,8 +40,11 @@ nix fmt            # Fix formatting
 
 ### Package placement
 
-See the `nix-package-placement` rule — auto-loads for `.nix` files, contains the full
-decision matrix for all four repos including homebrew constraints and on-demand patterns.
+See the `nix-package-placement` rule — lives in
+[ai-assistant-instructions/agentsmd/rules/nix-package-placement.md](https://github.com/JacobPEvans/ai-assistant-instructions/blob/main/agentsmd/rules/nix-package-placement.md)
+and auto-loads via path-scoping when `.nix` / `flake.*` files are in context.
+Contains the full decision matrix for all four repos including homebrew constraints
+and on-demand patterns.
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,9 +40,8 @@ nix fmt            # Fix formatting
 
 ### Package placement
 
-- **`home.packages`**: User dev tools, linters, CLIs, language runtimes
-- **`environment.systemPackages`** (nix-darwin): Core bootstrapping (git, vim), macOS-only system tools, GUI apps, audio libs
-- **AI packages** (nix-ai): Claude Code, Gemini, Copilot, MCP servers
+See the `nix-package-placement` rule — auto-loads for `.nix` files, contains the full
+decision matrix for all four repos including homebrew constraints and on-demand patterns.
 
 ## Architecture
 

--- a/cspell.json
+++ b/cspell.json
@@ -19,7 +19,8 @@
     "tflint",
     "venv",
     "worktree",
-    "worktrees"
+    "worktrees",
+    "mkshell"
   ],
   "ignorePaths": [
     "flake.lock",

--- a/modules/common/packages.nix
+++ b/modules/common/packages.nix
@@ -64,14 +64,6 @@ lib.optionals pkgs.stdenv.isLinux [
   zellij # Modern terminal multiplexer (Rust, layout engine)
 
   # ==========================================================================
-  # Visualization & Diagramming
-  # ==========================================================================
-  # CLI tools for generating diagrams from text/code.
-
-  # d2 and mermaid-cli removed — use `nix run nixpkgs#d2` and `nix run nixpkgs#mermaid-cli`
-  # for occasional diagramming (zero install, zero residue)
-
-  # ==========================================================================
   # Document Processing (Claude document-skills)
   # ==========================================================================
   # Runtime dependencies for /document-skills:{docx,xlsx,pptx} — text
@@ -92,15 +84,11 @@ lib.optionals pkgs.stdenv.isLinux [
   # Shell
   shellcheck # Shell script static analysis (POSIX, bash)
   shfmt # Shell script formatter
-  # bats removed — Bash testing belongs in project devenvs (nix-devenv shells/ansible)
 
   # Documentation
   cspell # Spell checker for code and documentation
-  lychee # Link checker for markdown and HTML — kept global: pre-commit uses language: system
+  lychee # Link checker — kept global: consumed by downstream repo pre-commit hooks (`language: system`)
   markdownlint-cli2 # Markdown linter (README, docs exist everywhere)
-
-  # CI/CD
-  # actionlint removed — GitHub Actions linting belongs in project devenvs (nix-devenv shells/kubernetes)
 
   # Nix (2025 official tooling)
   nixfmt-rfc-style # Official Nix formatter (RFC 166, v1.1.0+)
@@ -157,27 +145,24 @@ lib.optionals pkgs.stdenv.isLinux [
   # Type checking and analysis tools for Python development.
   pyright # Static type checker for Python
 
-  # Python interpreters: Single version (python314) — python312 removed (no unique users;
-  # brew provides python@3.12 as a transitive dep of gemini-cli/node/etc.)
+  # Single Python interpreter (python314) — python312 removed (no unique users
+  # in the quartet; `uv run --python 3.12` covers ad-hoc 3.12 needs).
   # NOTE: python3 cannot be overridden at the overlay level on Darwin because
-  # it is used by stdenv bootstrapping (AvailabilityVersions). Reference python314 explicitly.
-  # For Python 3.9 (Splunk, EOL): Use `uv run --python 3.9` (on-demand download)
-  # For Python 3.12: Use brew python@3.12 or `uv run --python 3.12`
+  # it's used by stdenv bootstrapping. Reference python314 explicitly.
 
-  # uv: For running EOL Python versions (3.9) not in nixpkgs
+  # uv: For running alternate Python versions on-demand (EOL or pinned)
   # Usage: uv run --python 3.9 pytest tests/
   uv
 
   # ==========================================================================
   # Python Environment
   # ==========================================================================
-  # Create a unified Python environment with all required packages.
-  # This ensures all modules can be imported in the same interpreter.
-  # Using python314.withPackages (overlay provides grip package).
+  # Unified Python environment for credential/secret scripts, GitHub automation,
+  # and Claude document-skills runtime. All modules importable from one interpreter.
+  # Note: this repo's flake also exports `grip` as a standalone package
+  # (nix run .#grip) via overlays/python-packages.nix + packages/grip.nix.
   (python314.withPackages (ps: [
     ps.cryptography # Cryptographic recipes and primitives
-    # grip removed — use `nix run nixpkgs#python3Packages.grip` for occasional markdown preview
-    # pipx removed — antipattern in Nix; use `nix run` or project devenv instead
     ps.pygithub # GitHub API v3 Python library
     # Claude document-skills dependencies
     ps.pandas # xlsx: data manipulation

--- a/modules/common/packages.nix
+++ b/modules/common/packages.nix
@@ -68,7 +68,7 @@ lib.optionals pkgs.stdenv.isLinux [
   # ==========================================================================
   # CLI tools for generating diagrams from text/code.
 
-  # d2 and mermaid-cli removed — use `nix run nixpkgs#d2` / `nix run nixpkgs#nodePackages.mermaid-cli`
+  # d2 and mermaid-cli removed — use `nix run nixpkgs#d2` and `nix run nixpkgs#mermaid-cli`
   # for occasional diagramming (zero install, zero residue)
 
   # ==========================================================================

--- a/modules/common/packages.nix
+++ b/modules/common/packages.nix
@@ -68,8 +68,8 @@ lib.optionals pkgs.stdenv.isLinux [
   # ==========================================================================
   # CLI tools for generating diagrams from text/code.
 
-  d2 # Modern diagram scripting language (D2lang)
-  mermaid-cli # Mermaid diagram generator CLI (mmdc)
+  # d2 and mermaid-cli removed — use `nix run nixpkgs#d2` / `nix run nixpkgs#nodePackages.mermaid-cli`
+  # for occasional diagramming (zero install, zero residue)
 
   # ==========================================================================
   # Document Processing (Claude document-skills)
@@ -92,15 +92,15 @@ lib.optionals pkgs.stdenv.isLinux [
   # Shell
   shellcheck # Shell script static analysis (POSIX, bash)
   shfmt # Shell script formatter
-  bats # Bash Automated Testing System for shell script testing
+  # bats removed — Bash testing belongs in project devenvs (nix-devenv shells/ansible)
 
   # Documentation
   cspell # Spell checker for code and documentation
-  lychee # Link checker for markdown and HTML (validates URLs in docs)
+  lychee # Link checker for markdown and HTML — kept global: pre-commit uses language: system
   markdownlint-cli2 # Markdown linter (README, docs exist everywhere)
 
   # CI/CD
-  actionlint # GitHub Actions workflow linter
+  # actionlint removed — GitHub Actions linting belongs in project devenvs (nix-devenv shells/kubernetes)
 
   # Nix (2025 official tooling)
   nixfmt-rfc-style # Official Nix formatter (RFC 166, v1.1.0+)
@@ -157,22 +157,12 @@ lib.optionals pkgs.stdenv.isLinux [
   # Type checking and analysis tools for Python development.
   pyright # Static type checker for Python
 
-  # Python interpreters: Multiple versions via Nix (no pip - packages via Nix only)
-  # Available: python314 (with grip via overlay), python312
+  # Python interpreters: Single version (python314) — python312 removed (no unique users;
+  # brew provides python@3.12 as a transitive dep of gemini-cli/node/etc.)
   # NOTE: python3 cannot be overridden at the overlay level on Darwin because
-  # it is used by stdenv bootstrapping (AvailabilityVersions). Reference
-  # python314 explicitly instead.
+  # it is used by stdenv bootstrapping (AvailabilityVersions). Reference python314 explicitly.
   # For Python 3.9 (Splunk, EOL): Use `uv run --python 3.9` (on-demand download)
-  # python310 available per-repo via devShells
-  # Individual interpreters at lower meta.priority to avoid /bin/idle conflict
-  # with the python314.withPackages environment below and each other.
-  # Priority: python314.withPackages (5, default) > python312 (10)
-  # Version-specific binaries (python3.12, python3.14) are always available.
-  (python312.overrideAttrs (old: {
-    meta = old.meta // {
-      priority = 10;
-    };
-  })) # Python 3.12: General development and testing
+  # For Python 3.12: Use brew python@3.12 or `uv run --python 3.12`
 
   # uv: For running EOL Python versions (3.9) not in nixpkgs
   # Usage: uv run --python 3.9 pytest tests/
@@ -186,8 +176,8 @@ lib.optionals pkgs.stdenv.isLinux [
   # Using python314.withPackages (overlay provides grip package).
   (python314.withPackages (ps: [
     ps.cryptography # Cryptographic recipes and primitives
-    ps.grip # Preview GitHub Markdown files locally
-    ps.pipx # Install and run Python CLI apps in isolated environments
+    # grip removed — use `nix run nixpkgs#python3Packages.grip` for occasional markdown preview
+    # pipx removed — antipattern in Nix; use `nix run` or project devenv instead
     ps.pygithub # GitHub API v3 Python library
     # Claude document-skills dependencies
     ps.pandas # xlsx: data manipulation


### PR DESCRIPTION
## Summary

Removes tools from always-on `home.packages` that are either project-scoped or ephemeral:

| Tool | Action | Destination |
| ---- | ------ | ----------- |
| `bats` | Removed | nix-devenv ansible shell |
| `actionlint` | Removed | nix-devenv kubernetes shell |
| `d2` | Removed | `nix run nixpkgs#d2` (on-demand) |
| `mermaid-cli` | Removed | `nix run nixpkgs#nodePackages.mermaid-cli` (on-demand) |
| `grip` | Removed from withPackages | `nix run nixpkgs#python3Packages.grip` (on-demand) |
| `pipx` | Removed from withPackages | Antipattern in Nix env; use `nix run` or devenv |
| `python312` | Removed | No references found across quartet; python314 is primary |
| `lychee` | **Kept** | pre-commit uses `language: system`, requires global PATH |
| `pyright` | **Kept** | IDEs require it in global PATH for background linting |

Also adds `mkshell` to `cspell.json` (pre-existing word in CLAUDE.md that triggered cspell).

## Test plan

- [ ] `nix flake check` passes
- [ ] `pre-commit run --all-files` passes (lychee still works)
- [ ] Cursor/VS Code pyright still active in projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)