### PR TITLE
fix(docs): drop 'quartet' and 'all four repos' language

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ nix fmt            # Fix formatting
 See the `nix-package-placement` rule — lives in
 [ai-assistant-instructions/agentsmd/rules/nix-package-placement.md](https://github.com/JacobPEvans/ai-assistant-instructions/blob/main/agentsmd/rules/nix-package-placement.md)
 and auto-loads via path-scoping when `.nix` / `flake.*` files are in context.
-Contains the full decision matrix for all four repos including homebrew constraints
+Contains the full decision matrix for the nix repos including homebrew constraints
 and on-demand patterns.
 
 ## Architecture
@@ -84,7 +84,7 @@ From nix-darwin, test changes with:
 sudo darwin-rebuild switch --flake . --override-input nix-home /Users/you/git/nix-home/main
 ```
 
-## Part of a Quartet
+## Related Repos
 
 | Repo | Purpose |
 |------|---------|

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ AI development workflows. It includes OpenTelemetry Collector for traces and log
 and Cribl Edge for log shipping. See [`modules/monitoring/README.md`](modules/monitoring/README.md)
 for architecture details, components, and quick start instructions.
 
-## Part of a Quartet
+## Related Repos
 
 **nix-home** manages your user-level development environment using home-manager modules.
 It provides shell config, editor settings, CLI dev tools, linters, and dotfiles.

--- a/modules/common/packages.nix
+++ b/modules/common/packages.nix
@@ -146,7 +146,7 @@ lib.optionals pkgs.stdenv.isLinux [
   pyright # Static type checker for Python
 
   # Single Python interpreter (python314) — python312 removed (no unique users
-  # in the quartet; `uv run --python 3.12` covers ad-hoc 3.12 needs).
+  # across the nix repos; `uv run --python 3.12` covers ad-hoc 3.12 needs).
   # NOTE: python3 cannot be overridden at the overlay level on Darwin because
   # it's used by stdenv bootstrapping. Reference python314 explicitly.
 


### PR DESCRIPTION
## Summary

Removes numeric-type group words ("quartet", "all four repos") from docs and a Nix comment. These words bake a repo count into the docs, so every time a repo is added or removed the docs have to be chased down and updated. Neutral phrasing ("the nix repos", "Related Repos") avoids that maintenance tax.

**Context**: Follow-up cleanup that didn't land in #146 before it was merged. The "Package placement" rewrite in #146 pointed at a new `nix-package-placement` rule (JacobPEvans/ai-assistant-instructions#554), but the surrounding docs still used "Part of a Quartet" and "all four repos".

## Changes

- `CLAUDE.md`: "Part of a Quartet" → "Related Repos"; "for all four repos" → "for the nix repos"
- `README.md`: "Part of a Quartet" → "Related Repos"
- `modules/common/packages.nix`: python312 comment "in the quartet" → "across the nix repos"

## Test plan

- [ ] CI passes (markdownlint, cspell, nix fmt)
- [ ] No functional changes — docs + a single comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)