### PR TITLE
fix(ci): dispatch flake-input-updated to nix-darwin on release

### DIFF
--- a/.github/scripts/check-release-on-commit.sh
+++ b/.github/scripts/check-release-on-commit.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Check if release-please created a release on the current commit.
+#
+# Compares the latest non-draft release tag's resolved commit SHA against
+# COMMIT_SHA. Only the latest release is checked because release-please
+# always creates releases on the merge commit of its release PR.
+#
+# Required env: GH_TOKEN, GITHUB_REPOSITORY, COMMIT_SHA, GITHUB_OUTPUT
+set -euo pipefail
+
+TAG=$(gh api "repos/${GITHUB_REPOSITORY}/releases" --jq \
+  "[.[] | select(.draft == false)] | first | .tag_name // empty")
+
+if [[ -z "$TAG" ]]; then
+  echo "No releases found"
+  echo "released=false" >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
+# Resolve the tag ref to a SHA. Lightweight tags point directly at the
+# commit; annotated tags point at a tag object that must be dereferenced.
+REF_OBJ=$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG}" --jq '.object')
+REF_TYPE=$(echo "$REF_OBJ" | jq -r '.type')
+REF_SHA=$(echo "$REF_OBJ" | jq -r '.sha')
+
+if [[ "$REF_TYPE" == "tag" ]]; then
+  # Annotated tag — dereference to the underlying commit
+  TAG_SHA=$(gh api "repos/${GITHUB_REPOSITORY}/git/tags/${REF_SHA}" --jq '.object.sha')
+else
+  # Lightweight tag — ref points directly at the commit
+  TAG_SHA="$REF_SHA"
+fi
+
+if [[ "$TAG_SHA" == "$COMMIT_SHA" ]]; then
+  echo "Release ${TAG} matches current commit"
+  echo "released=true" >> "$GITHUB_OUTPUT"
+  echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+else
+  echo "Latest release ${TAG} (${TAG_SHA}) does not match current commit (${COMMIT_SHA})"
+  echo "released=false" >> "$GITHUB_OUTPUT"
+fi

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -25,46 +25,15 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Checkout (for scripts)
+        uses: actions/checkout@v6
+
       - name: Check for new release on this commit
         id: check
         env:
           GH_TOKEN: ${{ github.token }}
           COMMIT_SHA: ${{ github.sha }}
-        run: |
-          # release-please tags the merge commit. Check if any release points
-          # at the commit that triggered this workflow run.
-          TAG=$(gh api "repos/${GITHUB_REPOSITORY}/releases" --jq \
-            "[.[] | select(.draft == false)] | first | .tag_name // empty")
-
-          if [[ -z "$TAG" ]]; then
-            echo "No releases found"
-            echo "released=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # Resolve the tag to a commit SHA and compare
-          TAG_SHA=$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG}" \
-            --jq '.object.sha' 2>/dev/null || echo "")
-
-          # Annotated tags need one more dereference
-          if [[ -n "$TAG_SHA" ]]; then
-            OBJ_TYPE=$(gh api "repos/${GITHUB_REPOSITORY}/git/tags/${TAG_SHA}" \
-              --jq '.object.type' 2>/dev/null || echo "commit")
-            if [[ "$OBJ_TYPE" == "commit" ]]; then
-              RESOLVED=$(gh api "repos/${GITHUB_REPOSITORY}/git/tags/${TAG_SHA}" \
-                --jq '.object.sha' 2>/dev/null || echo "$TAG_SHA")
-              TAG_SHA="$RESOLVED"
-            fi
-          fi
-
-          if [[ "$TAG_SHA" == "$COMMIT_SHA" ]]; then
-            echo "Release ${TAG} matches current commit"
-            echo "released=true" >> "$GITHUB_OUTPUT"
-            echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-          else
-            echo "Latest release ${TAG} (${TAG_SHA}) does not match current commit (${COMMIT_SHA})"
-            echo "released=false" >> "$GITHUB_OUTPUT"
-          fi
+        run: bash .github/scripts/check-release-on-commit.sh
 
       - name: Generate GitHub App Token (cross-repo dispatch)
         if: steps.check.outputs.released == 'true'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,3 +15,78 @@ jobs:
     secrets:
       GH_ACTION_JACOBPEVANS_APP_ID: ${{ secrets.GH_ACTION_JACOBPEVANS_APP_ID }}
       GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
+  # Notify downstream repos when a new release is published.
+  # The reusable _release-please.yml doesn't expose release outputs, so we
+  # check the API for a release created on the current commit instead.
+  notify-downstream:
+    needs: release-please
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check for new release on this commit
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COMMIT_SHA: ${{ github.sha }}
+        run: |
+          # release-please tags the merge commit. Check if any release points
+          # at the commit that triggered this workflow run.
+          TAG=$(gh api "repos/${GITHUB_REPOSITORY}/releases" --jq \
+            "[.[] | select(.draft == false)] | first | .tag_name // empty")
+
+          if [[ -z "$TAG" ]]; then
+            echo "No releases found"
+            echo "released=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Resolve the tag to a commit SHA and compare
+          TAG_SHA=$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG}" \
+            --jq '.object.sha' 2>/dev/null || echo "")
+
+          # Annotated tags need one more dereference
+          if [[ -n "$TAG_SHA" ]]; then
+            OBJ_TYPE=$(gh api "repos/${GITHUB_REPOSITORY}/git/tags/${TAG_SHA}" \
+              --jq '.object.type' 2>/dev/null || echo "commit")
+            if [[ "$OBJ_TYPE" == "commit" ]]; then
+              RESOLVED=$(gh api "repos/${GITHUB_REPOSITORY}/git/tags/${TAG_SHA}" \
+                --jq '.object.sha' 2>/dev/null || echo "$TAG_SHA")
+              TAG_SHA="$RESOLVED"
+            fi
+          fi
+
+          if [[ "$TAG_SHA" == "$COMMIT_SHA" ]]; then
+            echo "Release ${TAG} matches current commit"
+            echo "released=true" >> "$GITHUB_OUTPUT"
+            echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          else
+            echo "Latest release ${TAG} (${TAG_SHA}) does not match current commit (${COMMIT_SHA})"
+            echo "released=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Generate GitHub App Token (cross-repo dispatch)
+        if: steps.check.outputs.released == 'true'
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.GH_ACTION_JACOBPEVANS_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          repositories: nix-darwin
+
+      - name: Dispatch flake-input-updated to downstream repos
+        if: steps.check.outputs.released == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          TAG: ${{ steps.check.outputs.tag }}
+          REPO_NAME: ${{ github.event.repository.name }}
+        run: |
+          for downstream in nix-darwin; do
+            echo "Dispatching flake-input-updated to ${downstream} (input=${REPO_NAME}, version=${TAG})"
+            gh api "repos/JacobPEvans/${downstream}/dispatches" \
+              -f event_type=flake-input-updated \
+              -f "client_payload[input_name]=${REPO_NAME}" \
+              -f "client_payload[version]=${TAG}" \
+              -f "client_payload[source_repo]=${REPO_NAME}"
+          done


### PR DESCRIPTION
## Summary

Add event-driven downstream notification to `release-please.yml` — when nix-home publishes a release, dispatch `flake-input-updated` to nix-darwin so it immediately bumps its `flake.lock`.

## Changes

### `.github/workflows/release-please.yml`
Add `notify-downstream` job that runs after `release-please`. Checks if the latest release tag resolves to the current commit SHA, then dispatches to downstream repos.

### `.github/scripts/check-release-on-commit.sh` (new)
Extracted release detection logic. Properly handles lightweight vs annotated git tags by inspecting the ref object type before dereferencing. API errors fail the job rather than silently skipping dispatch.

## How it works

```
push to main → release-please (reusable workflow)
                    ↓
             notify-downstream job
                    ↓
             check-release-on-commit.sh
                    ↓ (latest tag == current commit)
             repository_dispatch → nix-darwin
                    ↓
             nix-darwin runs nix flake update nix-home → PR
```

## Test plan

- [x] Pre-commit hooks pass
- [ ] CI gate passes
- [ ] After merge, verify non-release pushes do NOT dispatch (tag won't match commit)
- [ ] After next release, verify dispatch fires and nix-darwin receives it

Related: JacobPEvans/nix-darwin#988

🤖 Generated with [Claude Code](https://claude.com/claude-code)
