### PR TITLE
fix(checks): avoid building activation pkg in module-eval check

### DIFF
--- a/lib/checks.nix
+++ b/lib/checks.nix
@@ -69,8 +69,7 @@
 
   # Verify the home-manager module evaluates without errors
   # Catches: broken imports, missing args, type errors, assertion failures
-  # Note: uses unsafeDiscardStringContext to eval without building the result —
-  # building the activation package requires packages not in the binary cache.
+  # Note: uses unsafeDiscardStringContext — forces eval without building packages absent from binary cache.
   module-eval =
     let
       # Use a pkgs instance with allowUnfree for the module eval check since

--- a/lib/checks.nix
+++ b/lib/checks.nix
@@ -69,6 +69,8 @@
 
   # Verify the home-manager module evaluates without errors
   # Catches: broken imports, missing args, type errors, assertion failures
+  # Note: uses unsafeDiscardStringContext to eval without building the result —
+  # building the activation package requires packages not in the binary cache.
   module-eval =
     let
       # Use a pkgs instance with allowUnfree for the module eval check since
@@ -107,6 +109,9 @@
           }
         ];
       };
+      # Force full evaluation without building — avoids OOM from direnv fish tests
+      # (direnv-2.37.1 is absent from binary cache, its fish test gets SIGKILL'd).
+      evalResult = builtins.unsafeDiscardStringContext "${hmConfig.activationPackage}";
     in
-    hmConfig.activationPackage;
+    pkgs.writeText "module-eval" evalResult;
 }

--- a/overlays/python-packages.nix
+++ b/overlays/python-packages.nix
@@ -15,9 +15,7 @@
 { nixpkgs-unstable }:
 final: prev:
 let
-  pkgsUnstable = import nixpkgs-unstable {
-    inherit (prev.stdenv.hostPlatform) system;
-  };
+  pkgsUnstable = nixpkgs-unstable.legacyPackages.${prev.stdenv.hostPlatform.system};
 
   gripOverride = python-final: _python-prev: {
     grip = python-final.callPackage ../packages/grip.nix { };


### PR DESCRIPTION
# Fix module-eval check OOM on aarch64-darwin

## Summary

Fixes OOM/SIGKILL failures on aarch64-darwin during `nix flake check` by addressing two
redundant Nixpkgs instantiations:

1. **Root cause 1** (`overlays/python-packages.nix`): Replaced `import nixpkgs-unstable {
   system; }` with `nixpkgs-unstable.legacyPackages.${system}`. The `import` form creates a
   fresh nixpkgs-unstable evaluation every time the overlay applies; `legacyPackages` reuses
   the memoized flake output, eliminating a ~1-2 GB redundant nixpkgs instance.

2. **Root cause 2** (`lib/checks.nix`): Changed `module-eval` check to return
   `pkgs.writeText` referencing the activation package's store path via
   `builtins.unsafeDiscardStringContext`, instead of directly returning
   `hmConfig.activationPackage`.

   `direnv-2.37.1` (a transitive dependency of the activation package) is absent from the
   binary cache for aarch64-darwin and must be built from source. Its `make test-fish` step
   is SIGKILL'd — either OOM or sandbox resource limits. By evaluating the activation
   package without building it, all module errors (broken imports, type errors, assertion
   failures) are still caught at evaluation time, while the heavy build phase is skipped
   entirely.

## Changes

- **overlays/python-packages.nix**: Use `legacyPackages` instead of `import` to prevent redundant Nixpkgs instantiation
- **lib/checks.nix**: Discard string context in module-eval check to avoid building the full activation package closure
- **lib/checks.nix**: Tighten module-eval comment to single line for clarity

## Test Plan

- [x] `nix build .#checks.aarch64-darwin.module-eval` — passes (was previously SIGKILL'd)
- [x] `nix flake check` — all 5 checks pass (formatting, statix, deadnix, shellcheck, module-eval)
- [x] All pre-commit hooks pass

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
