### PR TITLE
refactor(zsh): move AI-tool aliases to nix-ai

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -21,6 +21,7 @@
   "fix": true,
   "gitignore": true,
   "ignores": [
-    ".github/aw/**"
+    ".github/aw/**",
+    "CHANGELOG.md"
   ]
 }

--- a/modules/home-manager/zsh/aliases.nix
+++ b/modules/home-manager/zsh/aliases.nix
@@ -74,12 +74,13 @@
   avr = "aws-vault remove"; # Remove profile from vault
 
   # ===========================================================================
-  # AI CLI Tools
+  # AI CLI Tools (Claude)
   # ===========================================================================
   # d-claude, tf-claude, claude-latest, claude-d, claude-latest-d and related
-  # AI-tool wrappers live in nix-ai's modules/ai-aliases.zsh (sourced by
-  # programs.zsh.initContent via nix-ai's modules/ai-shell.nix). Keeping them
-  # there centralizes AI-tool surface area in the nix-ai repo.
+  # Claude-specific wrappers now live in nix-ai's modules/ai-aliases.zsh
+  # (sourced by programs.zsh.initContent via nix-ai's modules/ai-shell.nix).
+  # The MLX aliases below stay here — they configure the local MLX dev env
+  # that lives in nix-home, not Claude Code.
 
   # ===========================================================================
   # tmux (session management)

--- a/modules/home-manager/zsh/aliases.nix
+++ b/modules/home-manager/zsh/aliases.nix
@@ -9,13 +9,6 @@
 #
 # Platform: macOS (BSD ls flags used)
 
-let
-  # Doppler wrapper that launches claude with 'ai-ci-automation/prd' secrets
-  # injected (GEMINI_API_KEY for Google Gemini / PAL MCP, OPENROUTER_API_KEY
-  # for OpenRouter, etc.). Bound once here so every alias that wants the
-  # same AI MCP context reuses the same command string.
-  dopplerClaude = "doppler run -p ai-ci-automation -c prd -- claude";
-in
 {
   # ===========================================================================
   # Directory Listing (macOS/BSD ls)
@@ -81,23 +74,12 @@ in
   avr = "aws-vault remove"; # Remove profile from vault
 
   # ===========================================================================
-  # AI CLI Tools (Doppler for secrets injection)
+  # AI CLI Tools
   # ===========================================================================
-  # Interactive Claude Code with ai-ci-automation/prd secrets injected.
-  # See the dopplerClaude binding at the top of this file for what's loaded.
-  #
-  # Usage:
-  #   d-claude             # Interactive Claude Code with injected secrets
-  #   d-claude -p "prompt" # Non-interactive with prompt
-  #
-  d-claude = dopplerClaude;
-
-  # aws-vault 'terraform' profile layered on top of d-claude. For sessions on
-  # infra repos that need BOTH AWS credentials AND AI MCP secrets loaded.
-  #
-  # Usage:
-  #   tf-claude             # AWS terraform profile + AI secrets + interactive claude
-  tf-claude = "aws-vault exec terraform -- ${dopplerClaude}";
+  # d-claude, tf-claude, claude-latest, claude-d, claude-latest-d and related
+  # AI-tool wrappers live in nix-ai's modules/ai-aliases.zsh (sourced by
+  # programs.zsh.initContent via nix-ai's modules/ai-shell.nix). Keeping them
+  # there centralizes AI-tool surface area in the nix-ai repo.
 
   # ===========================================================================
   # tmux (session management)


### PR DESCRIPTION
## Summary

Removes \`d-claude\`, \`tf-claude\`, and the \`dopplerClaude\` let-binding from \`modules/home-manager/zsh/aliases.nix\`. These aliases are AI-tool-specific (Claude Code + Doppler secrets injection) and belong with the rest of the AI surface area in nix-ai.

The companion nix-ai PR adds \`modules/ai-aliases.zsh\` and \`modules/ai-shell.nix\` that source into \`programs.zsh.initContent\` via \`lib.mkAfter\`. nix-home's base zsh config is untouched; AI aliases just live in a different repo now — plus new ones (\`claude-latest\`, \`claude-d\`, \`claude-latest-d\`) pairing with nix-ai's new \`programs.claude-latest\` module.

## Companion PR

- nix-ai: https://github.com/JacobPEvans/nix-ai/pull/new/feat/opus-high-effort-and-claude-latest

## Test plan

- [x] \`nix fmt\` clean
- [x] \`nix flake check\` passes
- [x] End-to-end darwin rebuild with both overrides succeeds; zsh aliases resolve identically (served from nix-ai)