### PR TITLE
refactor(zsh): :recycle: route mlx-coder/mlx-rag through ai-stack roles

### DIFF
--- a/modules/home-manager/zsh/aliases.nix
+++ b/modules/home-manager/zsh/aliases.nix
@@ -92,16 +92,17 @@
   # ===========================================================================
   # MLX (Apple Silicon ML Inference Server)
   # ===========================================================================
-  # The MLX stack is now an always-on LaunchAgent (vllm-mlx + llama-swap on
-  # port 11434, see nix-ai/modules/mlx/). These aliases switch the active
-  # backend by ROLE NAME; physical model IDs live in services.aiStack.models.
+  # The MLX stack is an always-on LaunchAgent (vllm-mlx + llama-swap on port
+  # 11434, defined in JacobPEvans/nix-ai modules/mlx/). These aliases switch
+  # the active backend by ROLE NAME; physical model IDs live in
+  # services.aiStack.models (nix-ai modules/ai-stack/default.nix):
   #
-  #   mlx-coder    -> services.aiStack.models.coding
-  #   mlx-rag      -> services.aiStack.models.large-context
-  #   mlx-default  -> restart proxy and reload the "default" role
+  #   mlx-coder -> services.aiStack.models.coding
+  #   mlx-rag   -> services.aiStack.models."large-context"
   #
-  # Override the role -> physical mapping in nix-ai/modules/ai-stack/default.nix
-  # without touching aliases.
-  mlx-coder = "mlx-switch coding";
-  mlx-rag = "mlx-switch large-context";
+  # The aliases call `mlx-switch`, which is provided by the nix-ai MLX
+  # module. They guard against `mlx-switch` being missing so this nix-home
+  # module remains usable without nix-ai installed.
+  mlx-coder = "command -v mlx-switch >/dev/null && mlx-switch coding || echo 'mlx-switch missing; enable JacobPEvans/nix-ai MLX module' >&2";
+  mlx-rag = "command -v mlx-switch >/dev/null && mlx-switch large-context || echo 'mlx-switch missing; enable JacobPEvans/nix-ai MLX module' >&2";
 }

--- a/modules/home-manager/zsh/aliases.nix
+++ b/modules/home-manager/zsh/aliases.nix
@@ -92,17 +92,16 @@
   # ===========================================================================
   # MLX (Apple Silicon ML Inference Server)
   # ===========================================================================
-  # On-demand MLX inference — no LaunchAgent, started manually when needed.
-  # Port 11435 avoids conflicts: Ollama (:11434), Open WebUI (:8080).
-  # mlx-server dir lives at ~/git/nix-ai/main/mlx-server/.
+  # The MLX stack is now an always-on LaunchAgent (vllm-mlx + llama-swap on
+  # port 11434, see nix-ai/modules/mlx/). These aliases switch the active
+  # backend by ROLE NAME; physical model IDs live in services.aiStack.models.
   #
-  # First-time setup: run `mlx-env` once to create the venv and install packages.
-  # Subsequent use: mlx-coder / mlx-rag source the existing venv directly.
+  #   mlx-coder    -> services.aiStack.models.coding
+  #   mlx-rag      -> services.aiStack.models.large-context
+  #   mlx-default  -> restart proxy and reload the "default" role
   #
-  # mlx-update: upgrades all MLX packages in-place (update uv.lock, then sync venv).
-  #
-  mlx-env = "cd ~/git/nix-ai/main/mlx-server && nix develop";
-  mlx-coder = "cd ~/git/nix-ai/main/mlx-server && source .venv/bin/activate && mlx_lm.server --model mlx-community/Qwen2.5-Coder-32B-Instruct-4bit --port 11435 --host 127.0.0.1";
-  mlx-rag = "cd ~/git/nix-ai/main/mlx-server && source .venv/bin/activate && mlx_lm.server --model mlx-community/c4ai-command-r-plus-08-2024-4bit --port 11435 --host 127.0.0.1";
-  mlx-update = "cd ~/git/nix-ai/main/mlx-server && nix develop --command bash -c 'uv lock --upgrade && uv sync'";
+  # Override the role -> physical mapping in nix-ai/modules/ai-stack/default.nix
+  # without touching aliases.
+  mlx-coder = "mlx-switch coding";
+  mlx-rag = "mlx-switch large-context";
 }


### PR DESCRIPTION
## Summary

Companion to **JacobPEvans/nix-ai#667**.

The old \`mlx-coder\` / \`mlx-rag\` aliases hardcoded physical \`mlx-community/*\` model IDs and pointed at a long-dead \`mlx_lm.server\` on port 11435. The MLX stack moved to vllm-mlx + llama-swap on port 11434 a while ago, and nix-ai introduced \`services.aiStack.models\` as the single source of truth for role → physical mappings.

The aliases now invoke \`mlx-switch <role>\` (provided by nix-ai's MLX module), so editing one Nix attr in \`services.aiStack.models\` swaps the backend everywhere — fabric, pal-mcp, screenpipe, and zsh — without any other consumer-side edit.

Dropped stale aliases: \`mlx-env\`, \`mlx-update\` (referenced \`~/git/nix-ai/main/mlx-server\` which has been gone since the llama-swap refactor).

## Test plan

- [ ] Merge JacobPEvans/nix-ai#667 first
- [ ] \`darwin-rebuild switch\` applies cleanly
- [ ] \`mlx-coder\` switches the backend to whatever \`services.aiStack.models.coding\` points at
- [ ] \`mlx-rag\` switches to \`services.aiStack.models.large-context\`
- [ ] \`type mlx-env mlx-update\` returns \`not found\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)