### PR TITLE
fix(ci): drop RunsOn from nix-validate gate path

### DIFF
--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -74,12 +74,11 @@ jobs:
     name: Nix Validate
     needs: changes
     if: needs.changes.outputs.nix == 'true'
+    # No `runner_label:` — keep this on ubuntu-latest. A self-hosted runner
+    # on a `needs:` of `Merge Gate` can queue forever with no terminal state,
+    # which prevents `gate` from ever running and leaves required-status
+    # absent. Opt into RunsOn only on workflows outside the gate path.
     uses: JacobPEvans/.github/.github/workflows/_nix-validate.yml@main
-    with:
-      # Only route same-repo PRs to the self-hosted RunsOn runner. Fork PRs
-      # fall back to ubuntu-latest so untrusted code from forks never lands
-      # on a runner with AWS credentials in scope.
-      runner_label: ${{ github.event.pull_request.head.repo.full_name == github.repository && format('runs-on={0}/runner=2cpu-linux-x64', github.run_id) || 'ubuntu-latest' }}
 
   markdown-lint:
     name: Markdown Lint


### PR DESCRIPTION
## Summary

- Drop the dynamic `runs-on=${run_id}/runner=2cpu-linux-x64` label from the `nix-validate` job in `ci-gate.yml`. `nix flake check` now runs on `ubuntu-latest`.
- Unblocks #205 and prevents the same failure mode for any future Renovate / bot PR.

## Why

When the RunsOn runner failed to claim the `Nix Validate / Validate` job (#205 sat in `queued` for the entire PR lifetime), the dependent `gate` job — which uses `if: ${{ !cancelled() }}` — never scheduled, because GitHub Actions only releases a `needs:` dependent once every upstream job reaches a *terminal* state (`success` / `failure` / `cancelled` / `skipped`). `queued` is not terminal, so `Merge Gate` was permanently absent and the PR was unmergeable.

`nix flake check` is a fast, cache-friendly evaluator that does not justify a self-hosted runner. RunsOn opt-in remains available for genuinely slow workloads (e.g. `_nix-build.yml`) that aren't on the `Merge Gate` critical path.

## Follow-up

A second PR will land in `JacobPEvans/.github` introducing `_ci-gate.yml` — a centralized gate with a watchdog job that cancels queued sibling jobs after a timeout, so any future opt-in to a self-hosted runner on the gate path can no longer wedge the gate. Once that ships, this repo's `ci-gate.yml` will collapse to a thin caller of the shared workflow.

## Test plan

- [ ] CI Gate runs cleanly on this PR (`Nix Validate / Validate` completes on ubuntu-latest in <2 min).
- [ ] After merge, close/reopen #205 (or rebase). Verify `Merge Gate` reports SUCCESS and Renovate's automerge takes the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)