### PR TITLE
fix(ci): remove deprecated app-id secret passthrough

### DIFF
--- a/.github/workflows/deps-update-flake.yml
+++ b/.github/workflows/deps-update-flake.yml
@@ -35,7 +35,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          client-id: ${{ secrets.GH_ACTION_JACOBPEVANS_APP_ID }}
+          client-id: ${{ vars.GH_APP_CLIENT_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
       - name: Checkout repository

--- a/.github/workflows/gh-aw-pin-refresh.yml
+++ b/.github/workflows/gh-aw-pin-refresh.yml
@@ -29,5 +29,4 @@ jobs:
     with:
       operation: ${{ inputs.operation || 'compile' }}
     secrets:
-      GH_ACTION_JACOBPEVANS_APP_ID: ${{ secrets.GH_ACTION_JACOBPEVANS_APP_ID }}
       GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,5 +13,4 @@ jobs:
       pull-requests: write
     uses: JacobPEvans/.github/.github/workflows/_release-please.yml@main
     secrets:
-      GH_ACTION_JACOBPEVANS_APP_ID: ${{ secrets.GH_ACTION_JACOBPEVANS_APP_ID }}
       GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary
- Removes `GH_ACTION_JACOBPEVANS_APP_ID` from the `secrets:` block in reusable workflow callers
- The central reusable workflows now read the GitHub App Client ID from `vars.GH_APP_CLIENT_ID` (a non-sensitive variable distributed by secrets-sync)

**Merge order:** JacobPEvans/secrets-sync#74 → JacobPEvans/.github#268 → this PR

## Changes
- `.github/workflows/deps-update-flake.yml`
- `.github/workflows/gh-aw-pin-refresh.yml`
- `.github/workflows/release-please.yml`

## Test Plan
- [ ] No deprecation warnings on `actions/create-github-app-token` after merging in order

🤖 Generated with [Claude Code](https://claude.com/claude-code)