### PR TITLE
chore(renovate): annotate docx and pptxgenjs version pins

### DIFF
--- a/modules/home-manager/document-skills.nix
+++ b/modules/home-manager/document-skills.nix
@@ -16,8 +16,9 @@
 { pkgs, lib, ... }:
 
 let
-  # Exact pins for reproducibility — bump deliberately.
+  # renovate: datasource=npm depName=docx
   docxVersion = "9.6.1";
+  # renovate: datasource=npm depName=pptxgenjs
   pptxgenjsVersion = "4.0.1";
 
   installScript = "${pkgs.install-document-skills-npm-deps}/bin/install-document-skills-npm-deps";


### PR DESCRIPTION
## Summary

- Add `# renovate:` annotations to `docxVersion` and `pptxgenjsVersion` in `modules/home-manager/document-skills.nix`
- Remove the inline comment that encouraged manual-only bumps (now contradictory since Renovate tracks these)

## Changes

Without these annotations, Renovate's custom regex manager could not detect the version literals. Both `docx` and `pptxgenjs` were silently untracked — any upstream release would be missed until a manual audit. This PR brings them into the standard org convention.

## Test Plan

- [ ] `nix flake check` passes in nix-home
- [ ] Renovate dry-run detects `docx` and `pptxgenjs` as tracked dependencies