### PR TITLE
feat(gpg-agent): unattended signing config for AI sessions

### DIFF
--- a/modules/home-manager/common.nix
+++ b/modules/home-manager/common.nix
@@ -49,7 +49,7 @@ let
   };
 
   # gpg-agent config (long cache TTL + pinentry-mac on Darwin)
-  gpgAgentFiles = import ./git/gpg-agent.nix { inherit pkgs lib; };
+  gpgAgentConfig = import ./git/gpg-agent.nix { inherit pkgs lib; };
 
   # Shell aliases
   shellAliases = import ./zsh/aliases.nix;
@@ -81,7 +81,8 @@ in
     # User dev tools (pre-commit, linters, Python, AWS, etc.)
     packages = commonPackages;
 
-    file = npmFiles // awsConfig.files // linterFiles // gitHooks // gitMergeDrivers // gpgAgentFiles;
+    file =
+      npmFiles // awsConfig.files // linterFiles // gitHooks // gitMergeDrivers // gpgAgentConfig.files;
 
     sessionVariables = {
       EDITOR = "vim";
@@ -92,7 +93,8 @@ in
       SCCACHE_CACHE_SIZE = "5G";
     };
 
-    activation = vscodeWritableConfig.activation // documentSkillsConfig.activation;
+    activation =
+      vscodeWritableConfig.activation // documentSkillsConfig.activation // gpgAgentConfig.activation;
   };
 
   programs = {

--- a/modules/home-manager/common.nix
+++ b/modules/home-manager/common.nix
@@ -48,6 +48,9 @@ let
     };
   };
 
+  # gpg-agent config (long cache TTL + pinentry-mac on Darwin)
+  gpgAgentFiles = import ./git/gpg-agent.nix { inherit pkgs lib; };
+
   # Shell aliases
   shellAliases = import ./zsh/aliases.nix;
 
@@ -78,7 +81,7 @@ in
     # User dev tools (pre-commit, linters, Python, AWS, etc.)
     packages = commonPackages;
 
-    file = npmFiles // awsConfig.files // linterFiles // gitHooks // gitMergeDrivers;
+    file = npmFiles // awsConfig.files // linterFiles // gitHooks // gitMergeDrivers // gpgAgentFiles;
 
     sessionVariables = {
       EDITOR = "vim";

--- a/modules/home-manager/git/gpg-agent.nix
+++ b/modules/home-manager/git/gpg-agent.nix
@@ -1,0 +1,21 @@
+# gpg-agent configuration for unattended commit signing.
+#
+# Long cache TTL (24h) prevents pinentry prompts during AI-driven sessions
+# that span hours. On Darwin, pinentry-mac is wired in so the prompt uses
+# the system Keychain UI instead of a TTY-only prompt that fails when
+# stdin is closed.
+#
+# Returns a home.file attrset (merged in common.nix). Empty on non-Darwin
+# so Linux gpg-agent defaults remain untouched.
+
+{ pkgs, lib }:
+
+lib.optionalAttrs pkgs.stdenv.isDarwin {
+  ".gnupg/gpg-agent.conf" = {
+    text = ''
+      default-cache-ttl 86400
+      max-cache-ttl 86400
+      pinentry-program ${pkgs.pinentry_mac}/bin/pinentry-mac
+    '';
+  };
+}

--- a/modules/home-manager/git/gpg-agent.nix
+++ b/modules/home-manager/git/gpg-agent.nix
@@ -5,17 +5,32 @@
 # the system Keychain UI instead of a TTY-only prompt that fails when
 # stdin is closed.
 #
-# Returns a home.file attrset (merged in common.nix). Empty on non-Darwin
-# so Linux gpg-agent defaults remain untouched.
+# Returns { files; activation; } matching the awsConfig pattern. The
+# activation step runs `gpgconf --reload gpg-agent` after home-manager
+# switch so changes take effect without requiring a logout. Both fields
+# are empty on non-Darwin so Linux gpg-agent defaults stay untouched.
 
 { pkgs, lib }:
 
-lib.optionalAttrs pkgs.stdenv.isDarwin {
-  ".gnupg/gpg-agent.conf" = {
-    text = ''
-      default-cache-ttl 86400
-      max-cache-ttl 86400
-      pinentry-program ${pkgs.pinentry_mac}/bin/pinentry-mac
+let
+  inherit (pkgs.stdenv) isDarwin;
+in
+{
+  files = lib.optionalAttrs isDarwin {
+    ".gnupg/gpg-agent.conf" = {
+      text = ''
+        default-cache-ttl 86400
+        max-cache-ttl 86400
+        pinentry-program ${pkgs.pinentry_mac}/bin/pinentry-mac
+      '';
+    };
+  };
+
+  activation = lib.optionalAttrs isDarwin {
+    reloadGpgAgent = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      # Picks up TTL/pinentry changes without requiring logout.
+      # Failure is non-fatal — agent isn't always running and starts on demand.
+      ${pkgs.gnupg}/bin/gpgconf --reload gpg-agent || true
     '';
   };
 }


### PR DESCRIPTION
## Summary

- New `modules/home-manager/git/gpg-agent.nix`, Darwin-only via `lib.optionalAttrs`.
- Sets `default-cache-ttl` and `max-cache-ttl` to 86400 (24h), points `pinentry-program` at `pkgs.pinentry_mac`.
- Wired into `common.nix`'s `home.file` merge.
- `nix flake check --no-build --impure` passes (`module-eval` green).

## Why

gpg-agent's default cache TTL is 10min idle / 2hr max — too short for multi-hour AI sessions. When the cache expires mid-session, gpg falls back to pinentry, which fails silently when stdin is detached. The result is the unsigned commit pattern: ~26 of the org's currently-open unsigned-commit PRs came from local Claude Code sessions where signing died like this.

Part of the cross-repo unsigned-commits cleanup (Phase 1 of plan: ~/.claude/plans/analyze-all-open-jacobpevans-giggly-cray.md). Pairs with JacobPEvans/claude-code-plugins#284 (sign-bypass guard) — together they make unsigned local commits structurally hard to produce.

The original plan called for restructuring `nix-home` with a `local.nix` overlay because the values would otherwise leak to a public repo — turns out `nix-darwin/lib/user-config.nix` already centralizes signing identity with explicit comments saying GPG key IDs and GitHub noreply emails are intentionally public. So that scaffolding is unneeded; this PR is the only Phase 1 nix change.

## Test plan

- [x] `nix flake check --no-build --impure` passes
- [ ] CI green
- [ ] After merge + `home-manager switch`: GPG signing works through a 24h+ AI session without re-prompting