### PR TITLE
fix(deps): bump nixpkgs past broken postgresql-test-hook rev

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -23,11 +23,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778030758,
-        "narHash": "sha256-8TXoMiLNpcYoKtglB6VK3zgcFw2elthUOL/1bmLBTkA=",
+        "lastModified": 1778111371,
+        "narHash": "sha256-L3LdhmeKcBrMVxqeEHwfwA1FFVf40DDCAOV8S0+PlLc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e3f3598f6dcc165901cf6e07d0f7c22a09df6b1c",
+        "rev": "25b257cc037722030ae920bba7c167d4db554a10",
         "type": "github"
       },
       "original": {
@@ -39,11 +39,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1778036283,
-        "narHash": "sha256-62EWg6lI0qyzm7oAx5cAnGkLutvJsRBe0KkEW2JDZCE=",
+        "lastModified": 1778274207,
+        "narHash": "sha256-I4puXmX1iovcCHZlRmztO3vW0mAbbRvq4F8wgIMQ1MM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ed67bc86e84e51d4a88e73c7fd36006dc876476f",
+        "rev": "b3da656039dc7a6240f27b2ef8cc6a3ef3bccae7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

- nixpkgs-25.11-darwin rev `e3f3598` marked `postgresql-test-hook` as `meta.broken = true` for darwin
- Caused `nix flake check` to fail in the `module-eval` check via the `python314.withPackages` closure in `modules/common/packages.nix`
- Bumps `nixpkgs` and `nixpkgs-unstable` to current tip; `25b257c` does not carry the broken mark
- All 5 checks pass locally: deadnix, shellcheck, statix, formatting, module-eval

## Changes

- `flake.lock`: nixpkgs-25.11-darwin `e3f3598` → `25b257c`, nixpkgs-unstable `ed67bc8` → `b3da656`

## Test Plan

- [x] `nix flake check -L` passes locally (all 5 checks green)
- [x] CI gate passes (Nix Validate, Merge Gate, CodeQL all SUCCESS)