### PR TITLE
feat(zsh): add clear-mem alias for refreshing local LLM memory

### DIFF
--- a/modules/home-manager/zsh/aliases.nix
+++ b/modules/home-manager/zsh/aliases.nix
@@ -106,11 +106,10 @@
   mlx-coder = "command -v mlx-switch >/dev/null && mlx-switch coding || echo 'mlx-switch missing; enable JacobPEvans/nix-ai MLX module' >&2";
   mlx-rag = "command -v mlx-switch >/dev/null && mlx-switch large-context || echo 'mlx-switch missing; enable JacobPEvans/nix-ai MLX module' >&2";
 
-  # Force-release wired memory held by local LLM processes when the system
-  # is thrashing. SIGKILLs vllm-mlx (which retains Metal/GPU buffers in
-  # unified memory even after llama-swap's /unload — these don't show up in
-  # ps RSS) and screenpipe's pi-coding-agent. llama-swap respawns vllm-mlx
-  # on the next inference request with a fresh allocation.
-  # Docs: ~/git/mlx-benchmarks/main/docs/quick-reset.md
-  clear-mem = "pkill -9 -f 'vllm-mlx serve' 2>/dev/null; pkill -f pi-coding-agent 2>/dev/null; sleep 1; echo '--- after clear-mem ---'; vm_stat | grep -E 'Pages (wired|free)'; sysctl vm.swapusage";
+  # Refresh memory held by large local LLMs for a performance boost.
+  # On Apple Silicon unified memory, MLX retains buffer allocations across
+  # requests for efficient reuse; over long sessions this accumulates beyond
+  # the active working set. Stopping the vllm-mlx backend returns that memory
+  # to the OS; llama-swap respawns it cleanly on the next inference request.
+  clear-mem = "pkill -9 -f 'vllm-mlx serve' 2>/dev/null; sleep 1; echo '--- after clear-mem ---'; vm_stat | grep -E 'Pages (wired|free)'; sysctl vm.swapusage";
 }

--- a/modules/home-manager/zsh/aliases.nix
+++ b/modules/home-manager/zsh/aliases.nix
@@ -105,4 +105,12 @@
   # module remains usable without nix-ai installed.
   mlx-coder = "command -v mlx-switch >/dev/null && mlx-switch coding || echo 'mlx-switch missing; enable JacobPEvans/nix-ai MLX module' >&2";
   mlx-rag = "command -v mlx-switch >/dev/null && mlx-switch large-context || echo 'mlx-switch missing; enable JacobPEvans/nix-ai MLX module' >&2";
+
+  # Force-release wired memory held by local LLM processes when the system
+  # is thrashing. SIGKILLs vllm-mlx (which retains Metal/GPU buffers in
+  # unified memory even after llama-swap's /unload — these don't show up in
+  # ps RSS) and screenpipe's pi-coding-agent. llama-swap respawns vllm-mlx
+  # on the next inference request with a fresh allocation.
+  # Docs: ~/git/mlx-benchmarks/main/docs/quick-reset.md
+  clear-mem = "pkill -9 -f 'vllm-mlx serve' 2>/dev/null; pkill -f pi-coding-agent 2>/dev/null; sleep 1; echo '--- after clear-mem ---'; vm_stat | grep -E 'Pages (wired|free)'; sysctl vm.swapusage";
 }


### PR DESCRIPTION
## Summary

Adds a `clear-mem` zsh alias that refreshes memory held by the local LLM stack for a performance boost between workloads.

```sh
clear-mem
# Stops the vllm-mlx backend so llama-swap respawns it with a fresh allocation
# on the next inference request, then prints the new wired/free/swap state.
```

## Why this exists

On Apple Silicon unified memory, MLX retains buffer allocations across requests for efficient reuse. Over long sessions — long benchmark sweeps, many model switches — this accumulates beyond the active working set. Stopping the backend returns that memory to the OS; llama-swap respawns it cleanly on the next inference request, so there is nothing else to start.

`POST /unload` on llama-swap only drops the model from its routing table; the underlying vllm-mlx process keeps its Metal buffers wired until it exits.

Full background: [mlx-benchmarks docs/quick-reset.md](https://github.com/JacobPEvans/mlx-benchmarks/pull/42) (companion PR).

## Test plan

- [ ] `darwin-rebuild switch --flake .` applies cleanly
- [ ] `clear-mem` available in a fresh shell
- [ ] Running it stops vllm-mlx and prints memory state
- [ ] Next inference request to llama-swap respawns vllm-mlx successfully