### PR TITLE
fix(flake): scope checks to x86_64-linux for --all-systems compatibility

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -53,19 +53,33 @@
         (import ./overlays/darwin-test-skips.nix)
       ];
 
-      # Quality checks (formatting, linting, dead code)
-      checks = forAllSystems (
-        system:
+      # Quality checks (formatting, linting, dead code, module-eval).
+      #
+      # Scoped to x86_64-linux only so `nix flake check --all-systems` succeeds
+      # from a single linux runner. All checks here are either source-only
+      # (formatting, statix, deadnix, shellcheck — identical source across
+      # systems) or wrap evaluation in a writeText (module-eval), so running
+      # them once is sufficient and produces a derivation buildable on the
+      # runner. Other systems intentionally have no `checks` entries.
+      #
+      # Cross-platform breakage (e.g. darwin-only `meta.broken` in nixpkgs) is
+      # still caught by `--all-systems` evaluating `packages.<system>`,
+      # `devShells.<system>`, `formatter.<system>`, and `overlays` for every
+      # declared system — those outputs continue to be defined via
+      # `forAllSystems` below.
+      checks =
         let
+          system = "x86_64-linux";
           pkgs = nixpkgs.legacyPackages.${system};
         in
-        import ./lib/checks.nix {
-          inherit pkgs nixpkgs home-manager;
-          src = ./.;
-          homeModule = self.homeManagerModules.default;
-          overlay = self.overlays.default;
-        }
-      );
+        {
+          ${system} = import ./lib/checks.nix {
+            inherit pkgs nixpkgs home-manager;
+            src = ./.;
+            homeModule = self.homeManagerModules.default;
+            overlay = self.overlays.default;
+          };
+        };
 
       # Development shells
       devShells = forAllSystems (


### PR DESCRIPTION
## Summary

- `nix flake check --all-systems` (default in `_nix-validate.yml`) was failing this repo's CI with **12 platform-mismatch errors** on `checks.{aarch64-linux,x86_64-darwin,aarch64-darwin}.*` because the x86_64-linux runner cannot build derivations bound to other systems.
- This PR scopes `checks` to `x86_64-linux` only. All current checks are either source-only (formatting, statix, deadnix, shellcheck — identical source across systems) or evaluation-wrapped (module-eval — already skips darwin with a string fallback). Running them once on the CI system is equivalent.
- Cross-platform breakage is still caught: `packages.<system>`, `devShells.<system>`, `formatter.<system>`, and `overlays` remain `forAllSystems`, so `--all-systems` continues to surface darwin-only `meta.broken` packages in nixpkgs.

## Why this fix and not the opt-in workaround

PR [JacobPEvans/.github#300](https://github.com/JacobPEvans/.github/pull/300) added an `all_systems` input (default `true`) so platform-specific repos could opt out. PR [JacobPEvans/.github#313](https://github.com/JacobPEvans/.github/pull/313) (companion to this one) plumbs that input through `_ci-gate.yml`. But the goal is `--all-systems` stays on by default everywhere — opting out is a defensive safety valve, not the desired path. This flake-level fix makes the opt-out unnecessary for nix-home: `--all-systems` succeeds with the default.

## Evidence of the original failure

[Run 25863775332 on PR #240](https://github.com/JacobPEvans/nix-home/actions/runs/25863775332/job/76007042675):

```
❌ checks.aarch64-linux.formatting   — Required aarch64-linux, Current x86_64-linux
❌ checks.x86_64-darwin.module-eval  — Required x86_64-darwin, Current x86_64-linux
❌ checks.aarch64-darwin.shellcheck  — Required aarch64-darwin, Current x86_64-linux
... (12 total)
✅ checks.x86_64-linux.{shellcheck, statix, module-eval, formatting, deadnix}  ALL PASS
```

## Verification

Local `nix flake check --all-systems --print-build-logs --show-trace --keep-going` from this branch (on aarch64-darwin) confirms:

- All `devShells.<system>.default`, `packages.<system>.*`, `formatter.<system>` evaluate ✅ across all 4 systems
- Only `checks.x86_64-linux.*` are declared — no more cross-system check derivations
- The local "Cannot build x86_64-linux drv on aarch64-darwin" errors are expected on my machine and will not appear on the x86_64-linux CI runner

## Test plan

- [ ] CI on this PR: `Nix Validate / Validate` passes (was failing before with 12 platform-mismatch errors)
- [ ] After merge, re-running CI on PR #240 (and any other open nix-home PR) shows nix-validate green
- [ ] No regression in other gate checks (Markdown Lint, File Size, Merge Gate)