### PR TITLE
fix(python): skip speechrecognition tests on darwin

### DIFF
--- a/overlays/python-packages.nix
+++ b/overlays/python-packages.nix
@@ -36,6 +36,8 @@ let
   #     `import av` (sandbox kills the av subprocess that loads ffmpeg libs)
   #   - faster-whisper: same sandbox kill on its import / test phases (av is
   #     a runtime dep, so disable proactively)
+  #   - speechrecognition: pytestCheckPhase SIGKILLed during test collection
+  #     (newer 3.16.x ships a pytest suite that exercises audio subprocesses)
   #
   # Setting both doCheck and doInstallCheck = false skips checkPhase and
   # the python-imports-check setup-hook (which lives in installCheckPhase).
@@ -52,6 +54,7 @@ let
     openai-whisper = skipDarwinChecks python-prev "openai-whisper";
     av = skipDarwinChecks python-prev "av";
     faster-whisper = skipDarwinChecks python-prev "faster-whisper";
+    speechrecognition = skipDarwinChecks python-prev "speechrecognition";
   };
 in
 {


### PR DESCRIPTION
## Summary

- Adds `speechrecognition` to `pythonPackageOverrides` in `overlays/python-packages.nix` with `doCheck = false`
- Follows the existing pattern for `openai-whisper`, `av`, `faster-whisper`

## Why

`speechrecognition 3.16.x` ships a pytest suite that gets SIGKILLed during test collection in the macOS Nix sandbox (audio subprocess kills — same class as the existing kvazaar/chromaprint/whisper skips).

## Reproduction

`darwin-rebuild switch --flake .` on the nix-darwin flake-update worktree (after bumping nixpkgs to current main):

```
building '/nix/store/.../python3.14-speechrecognition-3.16.1.drv'...
> pytest flags: -m pytest --ignore-glob=tests/recognizers/test_vosk.py
> collecting 18 items   /nix/store/.../pytest-check-hook: line 23: Killed: 9
error: builder failed with exit code 137.
```

## Test plan

- [ ] nix-home CI passes
- [ ] darwin-rebuild succeeds in nix-darwin after pinning this version

Assisted-by: Claude <noreply@anthropic.com>