### PR TITLE
feat(zsh): GitHub PAT keychain helpers (gh_pat / with_gh_pat / elevate_unlock)

### DIFF
--- a/modules/home-manager/common.nix
+++ b/modules/home-manager/common.nix
@@ -71,6 +71,14 @@ let
       ;
   };
 
+  # GitHub PAT keychain helpers (gh_pat / with_gh_pat / elevate_unlock)
+  ghConfig = import ./gh/config.nix {
+    inherit
+      pkgs
+      userConfig
+      ;
+  };
+
   # Linter configurations
   linterFiles = import ./linters/markdownlint.nix { inherit config; };
 in
@@ -142,6 +150,7 @@ in
 
         # --- Shell modules ---
         ${lib.optionalString pkgs.stdenv.isDarwin "source ${awsConfig.initScript}"}
+        ${lib.optionalString pkgs.stdenv.isDarwin "source ${ghConfig.initScript}"}
         source ${./zsh/git-functions.zsh}
         source ${./zsh/docker-functions.zsh}
         source ${./zsh/process-cleanup.zsh}

--- a/modules/home-manager/gh/config.nix
+++ b/modules/home-manager/gh/config.nix
@@ -1,0 +1,25 @@
+# GitHub PAT keychain helpers (macOS only)
+#
+# Exposes `gh_pat`, `with_gh_pat`, `elevate_unlock` shell functions sourced
+# from zsh initContent. See keychain-helpers.zsh for the contract.
+#
+# userConfig.keychain.elevateAccount  — account name on keychain items (default "ai-cli-coder")
+# userConfig.keychain.elevateKeychain — keychain name without extension (default "elevate-access")
+
+{
+  pkgs,
+  userConfig ? { },
+  ...
+}:
+
+let
+  elevateAccount = (userConfig.keychain or { }).elevateAccount or "ai-cli-coder";
+  elevateKeychain = (userConfig.keychain or { }).elevateKeychain or "elevate-access";
+
+  helpersScript = pkgs.replaceVars ./keychain-helpers.zsh {
+    inherit elevateAccount elevateKeychain;
+  };
+in
+{
+  initScript = helpersScript;
+}

--- a/modules/home-manager/gh/keychain-helpers.zsh
+++ b/modules/home-manager/gh/keychain-helpers.zsh
@@ -1,0 +1,77 @@
+# GitHub PAT helpers for the macOS keychain.
+#
+# Reads GitHub Personal Access Tokens from a custom macOS keychain so that
+# multi-token workflows (cross-org admin, per-scope PATs) don't require
+# pasting tokens into env vars or files.
+#
+# Sourced from zsh initContent — runs as the user with full keychain access.
+# @-prefixed tokens are replaced by pkgs.replaceVars at Nix build time.
+#
+# One-time setup (per machine):
+#
+#   1. Create the keychain (Keychain Access.app → File → New Keychain) or
+#      reuse an existing one. Default name: "@elevateKeychain@".
+#   2. Add each PAT as a generic password:
+#        Service name: GH_PAT_<NAME>  (e.g., GH_PAT_ORG_ADMIN)
+#        Account:      @elevateAccount@
+#        Password:     <the PAT>
+#   3. Set the keychain auto-lock window to something workable:
+#        security set-keychain-settings -t 28800 -l \
+#          "$HOME/Library/Keychains/@elevateKeychain@.keychain-db"
+#   4. First time each PAT is read, the OS prompts for keychain unlock and
+#      asks "Allow / Always Allow / Deny". Click "Always Allow" so
+#      subsequent reads run silently for the keychain's timeout window.
+
+_GH_PAT_ACCOUNT="@elevateAccount@"
+_GH_PAT_KEYCHAIN_NAME="@elevateKeychain@"
+_GH_PAT_DB="$HOME/Library/Keychains/$_GH_PAT_KEYCHAIN_NAME.keychain-db"
+
+# Fetch a GitHub PAT by suffix.
+# Usage: gh_pat ORG_ADMIN  →  reads service "GH_PAT_ORG_ADMIN" from the keychain
+gh_pat() {
+  local pat_suffix="$1"
+  if [[ -z "$pat_suffix" ]]; then
+    echo "usage: gh_pat <SUFFIX>   e.g.: gh_pat ORG_ADMIN" >&2
+    return 1
+  fi
+  if [[ -z "$_GH_PAT_ACCOUNT" ]]; then
+    echo "gh_pat: keychain account not configured (userConfig.keychain.elevateAccount)" >&2
+    return 1
+  fi
+  security find-generic-password \
+    -a "$_GH_PAT_ACCOUNT" \
+    -s "GH_PAT_$pat_suffix" \
+    -w "$_GH_PAT_DB" 2>/dev/null
+}
+
+# Run a command with a specific PAT exported as GITHUB_TOKEN + GH_TOKEN.
+# Usage: with_gh_pat ORG_ADMIN -- gh pr list --repo dryvist/...
+#        with_gh_pat ORG_ADMIN tofu apply
+with_gh_pat() {
+  local pat_suffix="$1"; shift
+  if [[ "${1:-}" == "--" ]]; then
+    shift
+  fi
+  if [[ $# -eq 0 ]]; then
+    echo "usage: with_gh_pat <SUFFIX> [--] cmd [args...]" >&2
+    return 1
+  fi
+  local token
+  token="$(gh_pat "$pat_suffix")" || return 1
+  if [[ -z "$token" ]]; then
+    echo "with_gh_pat: empty token for GH_PAT_$pat_suffix" >&2
+    return 1
+  fi
+  GITHUB_TOKEN="$token" GH_TOKEN="$token" "$@"
+}
+
+# Unlock the elevate-access keychain (GUI password prompt via Security Agent).
+# Subsequent reads within the keychain's auto-lock window run silently if
+# the user has clicked "Always Allow" on each item.
+elevate_unlock() {
+  if [[ ! -f "$_GH_PAT_DB" ]]; then
+    echo "elevate_unlock: keychain not found at $_GH_PAT_DB" >&2
+    return 1
+  fi
+  security unlock-keychain "$_GH_PAT_DB"
+}


### PR DESCRIPTION
## Summary

Three zsh functions for reading GitHub PATs from a macOS keychain, eliminating
the recurring "GH_TOKEN env var is stale / pick the right token / keychain
prompts every time" pattern.

### New module: `modules/home-manager/gh/`

- `keychain-helpers.zsh` — function definitions, sourced from `programs.zsh.initContent`
- `config.nix` — Nix wrapper that does `pkgs.replaceVars` (matches `aws/config.nix` pattern)

Wired into `common.nix` and sourced only on Darwin.

### Functions

| Function | What it does |
|---|---|
| `gh_pat <SUFFIX>` | Echo PAT stored as service `GH_PAT_<SUFFIX>`, e.g. `gh_pat ORG_ADMIN` |
| `with_gh_pat <SUFFIX> [--] cmd args...` | Run `cmd` with `GITHUB_TOKEN` + `GH_TOKEN` set |
| `elevate_unlock` | Unlock the keychain (GUI prompt) |

### Config

- `userConfig.keychain.elevateAccount` — default `"ai-cli-coder"`
- `userConfig.keychain.elevateKeychain` — default `"elevate-access"`

Defaults match the current setup. Override in nix-darwin's `userConfig` if needed.

### One-time per-machine setup (documented inline in keychain-helpers.zsh)

```bash
security set-keychain-settings -t 28800 -l \
  "$HOME/Library/Keychains/elevate-access.keychain-db"
```

Then click **Always Allow** on first read of each PAT.

## Test plan

- [ ] CI: `nix flake check` green
- [ ] On next darwin-rebuild: `gh_pat ORG_ADMIN | head -c 20` prints token prefix
- [ ] `with_gh_pat ORG_ADMIN -- gh api user --jq .login` prints `JacobPEvans`