### PR TITLE
chore(packages): add lefthook to global PATH

### DIFF
--- a/modules/common/packages.nix
+++ b/modules/common/packages.nix
@@ -24,6 +24,14 @@ lib.optionals pkgs.stdenv.isLinux [
   # Framework for managing git pre-commit hooks - essential for code quality
   pre-commit
 
+  # Lefthook: Some upstream repos (e.g., docs.jacobpevans.com via Mintlify
+  # tooling) drop `lefthook`-generated hook stubs into `.git/hooks/`. Those
+  # stubs print "Can't find lefthook in PATH" warnings during ordinary git
+  # operations when the binary isn't installed. Keep it on PATH globally so
+  # the stubs run as intended (lefthook is a no-op without a `lefthook.yml`,
+  # matching pre-commit's behavior without `.pre-commit-config.yaml`).
+  lefthook
+
   # Git Workflow
   (pkgs.callPackage ./git-flow-next.nix { }) # git-flow branching workflow — required for all non-personal repos
   git-bug # Distributed bug tracker embedded in git (git bug command)


### PR DESCRIPTION
## Context

Surfaced during the [2026-05-22 workspace cleanup sweep](https://github.com/JacobPEvans/nix-home). Multiple sweep agents (docs, ansible-proxmox, tf-splunk-aws) noted `Can't find lefthook in PATH` warnings during ordinary git operations like rebase.

## Root cause

Some upstream repos drop lefthook-generated hook stubs into `.git/hooks/` via tooling like Mintlify. When the `lefthook` binary isn't installed system-wide, every git operation surfaces a noise warning.

## Fix

Add `lefthook` to `modules/common/packages.nix`. Per upstream docs, lefthook is a no-op without a `lefthook.yml` (matching pre-commit's behavior without `.pre-commit-config.yaml`), so it's safe to install globally even where no hooks exist.

## Test plan

- [x] `nix flake check --no-build` passes
- [ ] `home-manager switch --flake .` cleanly switches after merge
- [ ] Subsequent git operations no longer emit lefthook warnings on affected repos
- [ ] No regression in repos that already had lefthook installed in dev shells