### PR TITLE
feat: add GIT_HOME and GIT_HOME_PUBLIC sessionVariables

### DIFF
--- a/modules/home-manager/common.nix
+++ b/modules/home-manager/common.nix
@@ -87,6 +87,10 @@ in
     sessionVariables = {
       EDITOR = "vim";
       SOPS_AGE_KEY_FILE = "${config.home.homeDirectory}/.config/sops/age/keys.txt";
+      # Workspace roots. Reference these in docs, scripts, and commands
+      # instead of hard-coding /Users/<you>/git/...
+      GIT_HOME = "${config.home.homeDirectory}/git";
+      GIT_HOME_PUBLIC = "${config.home.homeDirectory}/git/public";
     }
     // lib.optionalAttrs pkgs.stdenv.isDarwin {
       HF_HOME = "/Volumes/HuggingFace";


### PR DESCRIPTION
## Summary

- Add `${GIT_HOME}` (`~/git`) and `${GIT_HOME_PUBLIC}` (`~/git/public`) to home-manager `sessionVariables`.
- Lets docs, scripts, and slash commands reference workspace roots without hard-coding `/Users/<you>/git/...` paths.

## Why

On 2026-05-25 all valid public `JacobPEvans/*` repos with bare + `main/` worktree structure were migrated from `~/git/<repo>/` to `~/git/public/<repo>/`. Private, dryvist, and non-bare clones stayed at `~/git/<repo>/`. Two roots now exist; both need stable, well-named env vars.

- `${GIT_HOME}` — workspace root for private, dryvist, non-bare entries
- `${GIT_HOME_PUBLIC}` — public bare-format repos

## Test plan

- [x] `nix flake check` on aarch64-darwin (passes)
- [x] `nix flake check --all-systems` — Linux checks need remote builder (pre-existing, unrelated)
- [ ] After merge: bump `nix-darwin` flake.lock, run `sudo darwin-rebuild switch --flake .`, confirm `echo $GIT_HOME` / `echo $GIT_HOME_PUBLIC` resolve in a fresh shell
- [ ] Follow-up PRs convert hard-coded path strings across nix repos to reference these vars (or `config.home.sessionVariables.GIT_HOME` from Nix eval). `modules/monitoring/default.nix` is one candidate (also needs the `kubernetes-monitoring` → `orbstack-kubernetes` rename to reflect the GitHub repo rename).

Assisted-by: Claude <noreply@anthropic.com>