### PR TITLE
refactor(monitoring): drop monitoring-deploy wrapper; keep orbstack-kubernetes pin

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -53,11 +53,28 @@
         "type": "github"
       }
     },
+    "orbstack-kubernetes": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1779727806,
+        "narHash": "sha256-oCP2oee7r+2j4+bxnIjLgpK1eKL/Ts3irga/ZnLhy/w=",
+        "owner": "JacobPEvans",
+        "repo": "orbstack-kubernetes",
+        "rev": "7621f8ec9d7d3b5d5403b7a0e1fe7ee8f3f04a0e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "JacobPEvans",
+        "repo": "orbstack-kubernetes",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "home-manager": "home-manager",
         "nixpkgs": "nixpkgs",
-        "nixpkgs-unstable": "nixpkgs-unstable"
+        "nixpkgs-unstable": "nixpkgs-unstable",
+        "orbstack-kubernetes": "orbstack-kubernetes"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -12,6 +12,16 @@
       url = "github:nix-community/home-manager/release-25.11";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+
+    # Source-only input: orbstack-kubernetes manifests + deploy scripts that
+    # modules/monitoring/monitoring-deploy executes. Pinned via flake.lock so
+    # deploys are reproducible across this nix-home generation. Override
+    # locally with `--override-input orbstack-kubernetes path:<checkout>` for
+    # development.
+    orbstack-kubernetes = {
+      url = "github:JacobPEvans/orbstack-kubernetes";
+      flake = false;
+    };
   };
 
   outputs =
@@ -20,6 +30,7 @@
       nixpkgs,
       nixpkgs-unstable,
       home-manager,
+      orbstack-kubernetes,
       ...
     }:
     let
@@ -36,6 +47,11 @@
       # Main home-manager module (cross-platform non-AI config)
       # Darwin modules imported unconditionally - they use mkEnableOption + mkIf,
       # so launchd config is only evaluated when explicitly enabled on macOS.
+      #
+      # `_module.args.orbstackKubernetesSrc` exposes the pinned source-only
+      # flake input to modules that need it (modules/monitoring), so the
+      # deploy commands resolve manifests from the Nix store rather than
+      # requiring a local clone of orbstack-kubernetes.
       homeManagerModules.default = {
         imports = [
           ./modules/home-manager/common.nix
@@ -43,6 +59,7 @@
           ./modules/monitoring
           ./modules/home-manager/darwin
         ];
+        _module.args.orbstackKubernetesSrc = orbstack-kubernetes;
       };
 
       # Python packages overlay

--- a/modules/monitoring/default.nix
+++ b/modules/monitoring/default.nix
@@ -1,8 +1,8 @@
 # Monitoring Infrastructure Module
 #
 # Provides deployment scripts and OTEL configuration for the monitoring stack.
-# Kubernetes manifests are managed in the kubernetes-monitoring repository:
-#   https://github.com/JacobPEvans/kubernetes-monitoring
+# Kubernetes manifests are managed in the orbstack-kubernetes repository:
+#   https://github.com/JacobPEvans/orbstack-kubernetes
 #
 # Usage:
 #   imports = [ ./modules/monitoring ];
@@ -10,6 +10,7 @@
   config,
   lib,
   pkgs,
+  orbstackKubernetesSrc,
   ...
 }:
 
@@ -25,8 +26,17 @@ in
 
       repoPath = lib.mkOption {
         type = lib.types.str;
-        default = "${config.home.homeDirectory}/git/kubernetes-monitoring/main";
-        description = "Path to the kubernetes-monitoring repository worktree";
+        default = "${orbstackKubernetesSrc}";
+        description = ''
+          Path to the orbstack-kubernetes source tree.
+
+          Defaults to the `orbstack-kubernetes` flake input (a Nix store
+          path), which makes deploys reproducible against this nix-home
+          generation. Override to point at a local checkout if you need to
+          test manifest changes against a deploy, or use
+          `--override-input orbstack-kubernetes path:<checkout>` on the
+          consuming flake for the same effect at the flake level.
+        '';
       };
 
       namespace = lib.mkOption {
@@ -99,31 +109,17 @@ in
     home = {
       # Helper scripts for Kubernetes-based monitoring
       packages = lib.mkIf cfg.kubernetes.enable [
-        (pkgs.writeShellScriptBin "monitoring-deploy" ''
-          set -euo pipefail
-
-          REPO_PATH="${cfg.kubernetes.repoPath}"
-          export KUBE_CONTEXT="${cfg.kubernetes.context}"
-
-          if [ ! -d "$REPO_PATH" ]; then
-            echo "ERROR: kubernetes-monitoring repo not found at $REPO_PATH"
-            echo "Clone it:"
-            echo "  mkdir -p ~/git/kubernetes-monitoring"
-            echo "  git clone git@github.com:JacobPEvans/kubernetes-monitoring.git ~/git/kubernetes-monitoring/main"
-            exit 1
-          fi
-
-          echo "Deploying monitoring stack from: $REPO_PATH"
-          cd "$REPO_PATH"
-
-          # Doppler project/config stored in SOPS, deploy-doppler reads them
-          if [ -f secrets.enc.yaml ]; then
-            make deploy-doppler
-          else
-            echo "WARNING: No secrets.enc.yaml found, deploying without secrets"
-            make deploy
-          fi
-        '')
+        # NOTE: There is no `monitoring-deploy` wrapper here on purpose.
+        # The deploy pipeline lives in orbstack-kubernetes/Makefile (which
+        # calls scripts/deploy-doppler.sh → scripts/deploy.sh). Wrapping
+        # it from nix-home added no abstraction value beyond putting a
+        # name on $PATH — and the underlying scripts mutate the source
+        # tree (`generate-overlay.sh` writes back to `k8s/overlays/local/`),
+        # which conflicts with serving the source from the read-only Nix
+        # store. To deploy: `cd <orbstack-kubernetes worktree> && make
+        # deploy-doppler`. The `orbstack-kubernetes` flake input above
+        # keeps the manifests pinned + reachable for any downstream
+        # consumer that needs the path (e.g. `monitoring.kubernetes.repoPath`).
 
         (pkgs.writeShellScriptBin "monitoring-status" ''
           set -euo pipefail


### PR DESCRIPTION
## Summary

- **Delete `monitoring-deploy`** from nix-home. It was a `cd <repo> && make deploy-doppler` indirection that added no abstraction.
- **Keep the `orbstack-kubernetes` source-only flake input** so the manifest set is pinned in `flake.lock` and any downstream consumer can resolve `monitoring.kubernetes.repoPath` to a reproducible store path.
- **Keep `monitoring-status` and `monitoring-logs`** — they only call `kubectl`, never needed the source tree.
- Add an explanatory comment where the deploy wrapper used to live so this design stays intentional.

## Why

Original PR scope was "rename `kubernetes-monitoring` → `orbstack-kubernetes` in default paths." That uncovered the deeper question: why does this wrapper need to know about a path on disk at all?

Two earlier iterations:
1. Hard-code `${GIT_HOME_PUBLIC}/orbstack-kubernetes/main` — broke if the workspace convention changed.
2. Resolve a Nix flake input + stage to `mktemp` before `make` — works, but costs a script file (`scripts/monitoring-deploy.sh`), a Nix-store-to-`/tmp` `cp -R` + `chmod -R u+w` on every deploy, plus a `writeShellApplication` shim.

Removing the wrapper is the honest fix:
- The orbstack-kubernetes Makefile is already canonical (`make deploy-doppler`).
- The deploy pipeline mutates `k8s/overlays/local/` via `generate-overlay.sh`, which is fundamentally incompatible with serving the source from the read-only Nix store without a workaround.
- Anyone deploying is already in the orbstack-kubernetes worktree mental model.

## To deploy after this lands

```bash
cd ${GIT_HOME_PUBLIC}/orbstack-kubernetes/main
make deploy-doppler
```

## Test plan

- [x] `nix flake check` on aarch64-darwin (passes)
- [x] `darwin-rebuild build --flake . --override-input nix-home <branch>` in nix-darwin: builds successfully
- [x] Build closure contains `monitoring-status` and `monitoring-logs` only; `monitoring-deploy` is gone
- [x] `monitoring.kubernetes.repoPath` default still resolves to `${orbstack-kubernetes}` flake input (Nix store path) for any future consumer

## Related

- v1.23.0 (introduced `GIT_HOME` / `GIT_HOME_PUBLIC` sessionVariables): #261
- Workspace migration that moved orbstack-kubernetes to `${GIT_HOME_PUBLIC}/orbstack-kubernetes/main`: 2026-05-25
- This supersedes earlier attempts in this same branch that staged a temp copy + extracted shell script.

Assisted-by: Claude <noreply@anthropic.com>