### PR TITLE
feat(home): add GIT_HOME_PRIVATE sessionVariable

### DIFF
--- a/modules/home-manager/common.nix
+++ b/modules/home-manager/common.nix
@@ -91,6 +91,7 @@ in
       # instead of hard-coding /Users/<you>/git/...
       GIT_HOME = "${config.home.homeDirectory}/git";
       GIT_HOME_PUBLIC = "${config.home.homeDirectory}/git/public";
+      GIT_HOME_PRIVATE = "${config.home.homeDirectory}/git/dryvist-private";
     }
     // lib.optionalAttrs pkgs.stdenv.isDarwin {
       HF_HOME = "/Volumes/HuggingFace";


### PR DESCRIPTION
## Summary

- Adds `GIT_HOME_PRIVATE = \"\${config.home.homeDirectory}/git/dryvist-private\"` to `modules/home-manager/common.nix`, alongside the existing `GIT_HOME` and `GIT_HOME_PUBLIC`.
- Unlocks `\${GIT_HOME_PRIVATE}/<repo>/` as the canonical reference style in committed docs across every private repo.
- Future rename of the `dryvist-private` directory (to `JacobPEvans-private` per workspace plan) becomes a one-line change here instead of a sweep across every repo.

## Why

Path conventions to date have used `\${GIT_HOME}/dryvist-private/<repo>/`, which still hard-codes the org-internal directory name in every committed file. Introducing the variable obfuscates that detail so the literal never has to appear in committed code.

## Test plan

- [ ] `darwin-rebuild switch`
- [ ] `zsh -i -c 'echo \"GIT_HOME_PRIVATE=\$GIT_HOME_PRIVATE\"'` returns `/Users/<user>/git/dryvist-private`
- [ ] Existing `GIT_HOME` and `GIT_HOME_PUBLIC` still resolve

Refs: dryvist/nix-mac-performance (forthcoming PR will use this).