### PR TITLE
fix: update default git identity to JacobPEvans-personal login

### DIFF
--- a/modules/home-manager/common.nix
+++ b/modules/home-manager/common.nix
@@ -13,8 +13,8 @@
     };
     user = {
       name = "jevans";
-      email = "20714140+JacobPEvans@users.noreply.github.com";
-      fullName = "JacobPEvans";
+      email = "20714140+JacobPEvans-personal@users.noreply.github.com";
+      fullName = "JacobPEvans-personal";
     };
     git = {
       editor = "vim";


### PR DESCRIPTION
Update the default `userConfig` git identity (author name + noreply email) after
the personal account rename `JacobPEvans` -> `JacobPEvans-personal`. This is the
fallback default; the effective macbook-m4 identity (plus the signing-key swap)
lives in nix-darwin.

Refs: dryvist/nix-darwin#1152

Test: `nix flake check` passes.