### PR TITLE
fix(identity): nix-home standalone fallback git email to renamed account

### DIFF
--- a/modules/home-manager/common.nix
+++ b/modules/home-manager/common.nix
@@ -13,7 +13,10 @@
     };
     user = {
       name = "jevans";
-      email = "20714140+JacobPEvans@users.noreply.github.com";
+      # Renamed account: noreply email must be ...+JacobPEvans-personal@ or commits
+      # built from this standalone fallback fail signature verification (bad_email).
+      # On the live machine nix-darwin's user-config.nix overrides this default.
+      email = "20714140+JacobPEvans-personal@users.noreply.github.com";
       fullName = "JacobPEvans";
     };
     git = {


### PR DESCRIPTION
The `common.nix` `userConfig` fallback default still carried the pre-rename GitHub noreply email (`...+JacobPEvans@...`), which fails commit signature verification (`bad_email`). This default is only used for standalone nix-home builds — on the live machine the value is sourced from nix-darwin `lib/user-config.nix` (fixed in dryvist/nix-darwin#1155) — but updating it keeps standalone/CI builds consistent.

Companion to `dryvist/nix-darwin#1155` (the effective fix for this machine). `fullName` is display-only and unchanged; `signingKey` default stays empty for standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)