### PR TITLE
fix(git): drop global core.hooksPath; rely on init.templateDir + per-repo install

### DIFF
--- a/modules/home-manager/git/config.nix
+++ b/modules/home-manager/git/config.nix
@@ -31,13 +31,20 @@
       inherit (userConfig.git) editor;
       autocrlf = "input"; # LF on commit, unchanged on checkout (Unix-style)
       whitespace = "trailing-space,space-before-tab"; # Highlight whitespace issues
-      hooksPath = "${config.home.homeDirectory}/.git-templates/hooks"; # Global hooks for ALL repos
+      # core.hooksPath intentionally NOT set globally. Setting it makes
+      # `pre-commit install` (cachix/git-hooks.nix installationScript) refuse
+      # to install per-repo hooks with "Cowardly refusing to install hooks
+      # with core.hooksPath set". Pre-commit-using repos rely on per-repo
+      # .git/hooks/ populated by their dev shell. Repos without a Nix dev
+      # shell still get template hooks via init.templateDir below.
     };
 
     # Repository initialization
     init = {
       inherit (userConfig.git) defaultBranch;
-      # Auto-install hooks on new clones (Layer 1 of pre-commit enforcement)
+      # Seed new clones/inits with template hooks via git's native template
+      # mechanism. Files in ~/.git-templates/hooks are copied into .git/hooks/
+      # on `git init`/`git clone`. Passive — doesn't override per-repo hooks.
       templateDir = "${config.home.homeDirectory}/.git-templates";
     };
 

--- a/modules/home-manager/git/hooks.nix
+++ b/modules/home-manager/git/hooks.nix
@@ -1,10 +1,13 @@
-# Git Hooks (Global via core.hooksPath)
+# Git Hooks (Template via init.templateDir)
 #
-# These hooks apply to ALL git repos via core.hooksPath (set in common.nix).
+# These hooks are seeded into new clones / `git init` runs via
+# init.templateDir (set in git/config.nix). They are NOT set as
+# core.hooksPath — see the comment in git/config.nix for why.
 # They delegate to pre-commit framework if .pre-commit-config.yaml exists.
 #
 # Layer 1 of 3-layer defense:
-#   1. Global hooks (this) - fast local feedback on ALL repos
+#   1. Template hooks (this) - seeded on new clones; pre-commit install
+#      (run by per-repo Nix dev shells) handles existing repos
 #   2. AI deny list - blocks --no-verify bypass attempts
 #   3. GitHub branch protection - server-side guarantee
 

--- a/modules/precommit-tools/default.nix
+++ b/modules/precommit-tools/default.nix
@@ -7,7 +7,8 @@
 # - Security: Security-focused checks
 #
 # These tools run via .pre-commit-config.yaml during git commit.
-# Installation: `pre-commit install` (handled by core.hooksPath in git config)
+# Installation: per-repo `pre-commit install`, typically invoked from the
+# repo's Nix dev shellHook (e.g. cachix/git-hooks.nix installationScript).
 # Manual run: `pre-commit run --all-files`
 #
 # This module is a single source of truth for all pre-commit tooling,


### PR DESCRIPTION
## Summary

- Drops `core.hooksPath` from the home-manager git config so it no longer cascades to every repo
- Keeps `init.templateDir = ~/.git-templates` so new clones / `git init` still get template hooks (passive — no override of per-repo `.git/hooks/`)
- Updates inline docs in `hooks.nix` + `precommit-tools/default.nix` to describe the new template + per-repo install model

## Why

A globally-set `core.hooksPath` makes pre-commit's installer refuse:

```
[ERROR] Cowardly refusing to install hooks with `core.hooksPath` set.
hint: `git config --unset-all core.hooksPath`
```

Reproduces consistently on every direnv activation in repos that use cachix/git-hooks.nix (e.g. nix-claude-code), where `installationScript` runs `pre-commit install` in the dev `shellHook`. Result: pre-commit framework hooks never install, and the user gets cryptic stderr on every `cd`.

Per-repo Nix dev shells already invoke `pre-commit install` correctly. Removing the global override hands hook ownership back to them, which is what the cachix/git-hooks.nix design assumes. Layer 1 of the 3-layer defense (per `hooks.nix` docs) shifts from "active on ALL repos via core.hooksPath" to "seeded into new clones via templateDir, installed per-repo via dev shell" — same coverage in practice, no conflict with pre-commit framework.

## Migration

Existing repos with a stale local `core.hooksPath` (one was left behind in nix-claude-code) need a one-time:

```bash
git config --local --unset core.hooksPath
```

after `darwin-rebuild switch`. Then `cd` re-fires direnv and `pre-commit install` populates `.git/hooks/` cleanly.

## Test plan

- [x] `nix flake check` passes on the worktree
- [ ] After local `darwin-rebuild switch`, `git config --global --get core.hooksPath` returns empty
- [ ] `cd ~/git/public/nix-claude-code/main` triggers direnv with no "Cowardly refusing" errors
- [ ] `ls -la ~/git/public/nix-claude-code/main/.git/hooks/` shows pre-commit framework hooks installed
- [ ] New `git init` test repo still receives template hooks via `init.templateDir`

Refs: cachix/git-hooks.nix design (per-repo installationScript)