### PR TITLE
chore(deps): bump nixpkgs 25.11-darwin → 26.05-darwin

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,32 +7,32 @@
         ]
       },
       "locked": {
-        "lastModified": 1779506708,
-        "narHash": "sha256-QOD/CNm196nCJRheux/URi4/HE66fthdOMqCJoPP1Y0=",
+        "lastModified": 1779726825,
+        "narHash": "sha256-RUkMrREjKDQrA+dA9+xZviGAxM5W1aVdyOr/bSYpHrE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3ee51fbdac8c8bdfe1e7e1fcaba6520a563f394f",
+        "rev": "b179bde238977f7d4454fc770b1a727eaf55111c",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-25.11",
+        "ref": "release-26.05",
         "repo": "home-manager",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779495359,
-        "narHash": "sha256-KZ/9A3gvlKboDm2Kbv4A6KnfA9wMSfebyoEU91HeBn8=",
+        "lastModified": 1780180721,
+        "narHash": "sha256-bHHvsVgzvOE0SKJn2OB7LDKuiOpdkXS/eVqTiJDNVBI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2b76bb8a3c79707f0d0903e486da6d9851654c3c",
+        "rev": "9396caa0b59af6a17cac62008a72255b25e1e9a8",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-25.11-darwin",
+        "ref": "nixpkgs-26.05-darwin",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -5,11 +5,11 @@
   description = "Cross-platform home-manager modules (Nix flake)";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-25.11-darwin";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-26.05-darwin";
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
     home-manager = {
-      url = "github:nix-community/home-manager/release-25.11";
+      url = "github:nix-community/home-manager/release-26.05";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 

--- a/lib/checks.nix
+++ b/lib/checks.nix
@@ -75,10 +75,10 @@
       # Use a pkgs instance with allowUnfree for the module eval check since
       # the module enables vscode (unfree). On darwin, ps.pandas / ps.markitdown
       # transitively pull arrow-cpp via pyarrow's ARROW_HOME attribute; arrow-cpp
-      # has meta.broken on darwin in nixpkgs 25.11 — caught by `nix flake check
+      # has meta.broken on darwin in nixpkgs 26.05 — caught by `nix flake check
       # --all-systems` when evaluating the aarch64-darwin output from a linux
       # runner. Neither legacy `config.allowBroken = true` nor the new
-      # `config.problems.handlers` mechanism works on the 25.11-darwin branch,
+      # `config.problems.handlers` mechanism works on the 26.05-darwin branch,
       # so override `meta.broken = false` via a test-only overlay.
       # This is test-only; real deployments use their own nixpkgs config.
       pkgsWithUnfree = import nixpkgs {
@@ -118,12 +118,12 @@
       # (direnv-2.37.1 is absent from binary cache, its fish test gets SIGKILL'd).
       # Skip the darwin evaluation: ps.pandas / ps.markitdown transitively pull
       # arrow-cpp via pyarrow's ARROW_HOME, and arrow-cpp has meta.broken on
-      # darwin in nixpkgs 25.11. Nix laziness ensures hmConfig is not evaluated
+      # darwin in nixpkgs 26.05. Nix laziness ensures hmConfig is not evaluated
       # on darwin. Linux module-eval already covers the platform-independent
       # module structure.
       evalResult =
         if pkgs.stdenv.isDarwin then
-          "skipped on darwin: arrow-cpp meta.broken in nixpkgs 25.11"
+          "skipped on darwin: arrow-cpp meta.broken in nixpkgs 26.05"
         else
           builtins.unsafeDiscardStringContext "${hmConfig.activationPackage}";
     in

--- a/overlays/python-packages.nix
+++ b/overlays/python-packages.nix
@@ -1,7 +1,7 @@
 # Python Package Overlays
 #
 # Replaces python314 with nixpkgs-unstable's version where all packages
-# are Python 3.14-compatible. nixpkgs-25.11 ships outdated PyO3/pydantic-core/
+# are Python 3.14-compatible. nixpkgs-26.05 ships outdated PyO3/pydantic-core/
 # astor that can't build against Python 3.14's C API changes.
 #
 # Using the entire python314 (not individual packages) avoids Python derivation


### PR DESCRIPTION
Repoint nixpkgs and home-manager inputs from the 25.11 release channels
to 26.05 and relock. Comments referencing the pinned channel updated to
match.

Assisted-by: Claude:claude-opus-4-8[1m]
