### PR TITLE
feat(aws): generate tf-* profiles from a names list; add tf-unifi

### DIFF
--- a/modules/home-manager/aws/config.nix
+++ b/modules/home-manager/aws/config.nix
@@ -18,7 +18,8 @@ let
   # Placeholder replaced at shell init by keychain lookup
   accountIdPlaceholder = "__AWS_ACCOUNT_ID__";
 
-  profiles = [
+  # Base identities — heterogeneous, not role-assuming.
+  baseProfiles = [
     {
       name = "default";
       comment = "Default profile - used when no --profile is specified";
@@ -47,39 +48,18 @@ let
       name = "iam-user";
       comment = "IAM admin - bootstrap only, not for daily use";
     }
-
-    # Per-project Terraform profiles — assume role via base terraform identity
-    {
-      name = "tf-splunk-aws";
-      comment = "tf-splunk-aws: EC2, VPC, S3, IAM, SSM, CloudWatch, EventBridge";
-      source_profile = "terraform";
-      role_arn = "arn:aws:iam::${accountIdPlaceholder}:role/tf-splunk-aws";
-    }
-    {
-      name = "tf-proxmox";
-      comment = "tf-proxmox: Route53 DNS records";
-      source_profile = "terraform";
-      role_arn = "arn:aws:iam::${accountIdPlaceholder}:role/tf-proxmox";
-    }
-    {
-      name = "tf-bedrock";
-      comment = "tf-bedrock: Bedrock, CloudFormation, Lambda, IAM, CloudWatch, Budgets";
-      source_profile = "terraform";
-      role_arn = "arn:aws:iam::${accountIdPlaceholder}:role/tf-bedrock";
-    }
-    {
-      name = "tf-static-website";
-      comment = "tf-static-website: S3, CloudFront, ACM, Route53";
-      source_profile = "terraform";
-      role_arn = "arn:aws:iam::${accountIdPlaceholder}:role/tf-static-website";
-    }
-    {
-      name = "tf-runs-on";
-      comment = "tf-runs-on: EC2, App Runner, SQS, DynamoDB, S3, IAM, CloudWatch, Budgets, SNS";
-      source_profile = "terraform";
-      role_arn = "arn:aws:iam::${accountIdPlaceholder}:role/tf-runs-on";
-    }
   ];
+
+  # Per-project Terraform profiles, generated from ./tf-projects.nix. Each
+  # assumes role/tf-<name> via the shared `terraform` base identity (no MFA).
+  tfProfiles = map (name: {
+    name = "tf-${name}";
+    comment = "tf-${name}: assumes role/tf-${name} via the terraform base identity";
+    source_profile = "terraform";
+    role_arn = "arn:aws:iam::${accountIdPlaceholder}:role/tf-${name}";
+  }) (import ./tf-projects.nix);
+
+  profiles = baseProfiles ++ tfProfiles;
 
   generateProfile =
     profile:

--- a/modules/home-manager/aws/tf-projects.nix
+++ b/modules/home-manager/aws/tf-projects.nix
@@ -1,0 +1,11 @@
+# Per-project Terraform roles. Each name here generates an aws-vault profile
+# `tf-<name>` that assumes `role/tf-<name>` from the shared `terraform` base
+# identity (no MFA). Adding a project is a one-line edit: append its name.
+[
+  "splunk-aws"
+  "proxmox"
+  "bedrock"
+  "static-website"
+  "runs-on"
+  "unifi"
+]


### PR DESCRIPTION
# Refactor tf-* aws profiles to a names list; add tf-unifi

## What

The per-project `tf-*` profiles in `~/.aws/config` were copy-pasted blocks.
This replaces them with a single names list (`tf-projects.nix`) mapped into
profiles, and adds `unifi`.

- `modules/home-manager/aws/tf-projects.nix` — the single source of truth;
  adding a project is now a one-line edit.
- `config.nix` generates `tf-<name>` profiles from that list, each assuming
  `role/tf-<name>` from the shared `terraform` base identity (no MFA).

Net: 24 insertions, 33 deletions. The generated `~/.aws/config` is identical for
the existing roles except the per-role comments are now uniform — the permission
summaries lived only in the comment and are documented in each terraform repo.
The account ID stays a keychain-substituted placeholder (`__AWS_ACCOUNT_ID__`).

## Why

`terraform-unifi` needs its own `tf-unifi` identity instead of borrowing
`tf-proxmox`. Generating from a list also DRYs the config (the original ask).

## Apply

After merge: `darwin-rebuild switch` regenerates `~/.aws/config`. The `tf-unifi`
role itself is created by the `terraform-aws-template` bootstrap (separate repo).

## Verification

Generated config evaluated and confirmed — all six `tf-*` profiles including
`tf-unifi` render with the correct `role_arn`. `nixfmt --check`, `statix`, and
`deadnix` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
