### PR TITLE
docs: OpenTofu-first wording for nix-devenv shells

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,5 +90,5 @@ sudo darwin-rebuild switch --flake . --override-input nix-home /Users/you/git/ni
 |------|---------|
 | [nix-ai](https://github.com/JacobPEvans/nix-ai) | AI coding tools (Claude, Gemini, Copilot) |
 | **nix-home** (this repo) | Dev environment |
-| [nix-devenv](https://github.com/JacobPEvans/nix-devenv) | Reusable dev shells (Terraform, Ansible, K8s, AI/ML) |
+| [nix-devenv](https://github.com/JacobPEvans/nix-devenv) | Reusable dev shells (OpenTofu, Ansible, K8s, AI/ML) |
 | [nix-darwin](https://github.com/JacobPEvans/nix-darwin) | macOS system config (consumes nix-ai + nix-home) |

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Consumed as a flake input by nix-darwin (macOS) and usable standalone on Linux.
 |------|-------|-------------|
 | **nix-home** (you are here) | User environment (dotfiles, dev tools, LaunchAgents) | home-manager |
 | [nix-ai](https://github.com/JacobPEvans/nix-ai) | AI CLI ecosystem (Claude, Gemini, Copilot, MCP) | home-manager |
-| [nix-devenv](https://github.com/JacobPEvans/nix-devenv) | Reusable dev shells (Terraform, Ansible, K8s, AI/ML) | nix develop / flake init |
+| [nix-devenv](https://github.com/JacobPEvans/nix-devenv) | Reusable dev shells (OpenTofu, Ansible, K8s, AI/ML) | nix develop / flake init |
 | [nix-darwin](https://github.com/JacobPEvans/nix-darwin) | macOS system config (Dock, Finder, Homebrew, security) | nix-darwin |
 
 ## License


### PR DESCRIPTION
# OpenTofu-first wording (nix-home)

The nix-devenv row in the repo tables described the reusable dev shells as
"(Terraform, Ansible, K8s, AI/ML)". The shell provides `tofu`, so this updates
the wording to "(OpenTofu, …)" in `README.md` and `CLAUDE.md`.

Unchanged: the `terraform` base aws-vault profile and `tf-*` role names (fleet
IAM identities), and the `shells/terraform` nix-devenv path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
