### PR TITLE
feat(aws): tofu + tofu-admin identities; group tf-* by base

### DIFF
--- a/modules/home-manager/aws/config.nix
+++ b/modules/home-manager/aws/config.nix
@@ -48,16 +48,30 @@ let
       name = "iam-user";
       comment = "IAM admin - bootstrap only, not for daily use";
     }
+    {
+      name = "tofu";
+      comment = "tofu base identity - new projects; assumes tf-* roles, no resource permissions";
+    }
+    {
+      name = "tofu-admin";
+      comment = "tofu-admin - standalone one-time state-bucket bootstrap user (own creds)";
+    }
   ];
 
-  # Per-project Terraform profiles, generated from ./tf-projects.nix. Each
-  # assumes role/tf-<name> via the shared `terraform` base identity (no MFA).
-  tfProfiles = map (name: {
-    name = "tf-${name}";
-    comment = "tf-${name}: assumes role/tf-${name} via the terraform base identity";
-    source_profile = "terraform";
-    role_arn = "arn:aws:iam::${accountIdPlaceholder}:role/tf-${name}";
-  }) (import ./tf-projects.nix);
+  # Per-project profiles, generated from ./tf-projects.nix and grouped by the
+  # base identity each assumes from (no MFA). New projects live under `tofu`;
+  # legacy projects stay under `terraform` until migrated.
+  tfProjects = import ./tf-projects.nix;
+  mkTfProfiles =
+    base: names:
+    map (name: {
+      name = "tf-${name}";
+      comment = "tf-${name}: assumes role/tf-${name} via the ${base} base identity";
+      source_profile = base;
+      role_arn = "arn:aws:iam::${accountIdPlaceholder}:role/tf-${name}";
+    }) names;
+  tfProfiles =
+    (mkTfProfiles "terraform" tfProjects.terraform) ++ (mkTfProfiles "tofu" tfProjects.tofu);
 
   profiles = baseProfiles ++ tfProfiles;
 

--- a/modules/home-manager/aws/tf-projects.nix
+++ b/modules/home-manager/aws/tf-projects.nix
@@ -1,11 +1,15 @@
-# Per-project Terraform roles. Each name here generates an aws-vault profile
-# `tf-<name>` that assumes `role/tf-<name>` from the shared `terraform` base
-# identity (no MFA). Adding a project is a one-line edit: append its name.
-[
-  "splunk-aws"
-  "proxmox"
-  "bedrock"
-  "static-website"
-  "runs-on"
-  "unifi"
-]
+# Per-project roles, grouped by the base identity each assumes from (no MFA).
+# `tf-<name>` -> assumes `role/tf-<name>`. Add new projects under `tofu`; legacy
+# projects stay under `terraform` until migrated. One-line edit per project.
+{
+  terraform = [
+    "splunk-aws"
+    "proxmox"
+    "bedrock"
+    "static-website"
+    "runs-on"
+  ];
+  tofu = [
+    "unifi"
+  ];
+}


### PR DESCRIPTION
# tofu + tofu-admin identities; group tf-* profiles by base

Adds the new base identities for the separation-of-duties state-backend model:

- `tofu` — everyday base identity for new projects; assumes `tf-*` roles (no MFA).
- `tofu-admin` — standalone one-time state-bucket bootstrap user (own creds).

`tf-projects.nix` is now grouped by base identity: new projects (`unifi`) assume
via `tofu`; legacy projects (`proxmox`, `splunk-aws`, …) stay on `terraform`
until a separate migration. You inject one `tofu` credential and assume any
`tf-*` from it — the profiles are just role maps.

Generated `~/.aws/config` confirmed: `tofu`/`tofu-admin` base profiles;
`tf-unifi` → `source_profile = tofu`; legacy `tf-*` → `terraform`. Account ID
stays a keychain-substituted placeholder.

After merge: `darwin-rebuild switch` regenerates `~/.aws/config`; add the `tofu`
and `tofu-admin` access keys via `aws-vault add`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
