### PR TITLE
feat(ci): dispatch flake-input update to nix-darwin on release

### DIFF
--- a/.github/workflows/dispatch-lock-updates.yml
+++ b/.github/workflows/dispatch-lock-updates.yml
@@ -1,0 +1,18 @@
+# Dispatch: notify consumers after a nix-home release
+#
+# Target repos are read from the DISPATCH_CONSUMERS repository variable
+# (JSON array, e.g. '["nix-darwin"]'). Add a new consumer there without
+# touching this file.
+name: Dispatch lock updates on release
+
+on:
+  release:
+    types: [published]
+
+permissions: {}
+
+jobs:
+  dispatch:
+    uses: dryvist/.github/.github/workflows/_dispatch-flake-consumers.yml@main
+    # source_input defaults to the calling repo name (nix-home).
+    secrets: inherit


### PR DESCRIPTION
## Summary

- Adds the missing sender edge: when a nix-home release is published, this
  workflow fires a `repository_dispatch` to all repos in `DISPATCH_CONSUMERS`
  (set to `["nix-darwin"]` — variable already configured)
- Delegates to the existing `dryvist/.github/_dispatch-flake-consumers.yml`
  reusable, matching the pattern already used by `nix-claude-code`
- After this lands, nix-darwin receives automated `nix-home` flake input bumps
  within minutes of a release, with no polling

## Test plan

- [x] `actionlint` exits 0 on the new file
- [x] `DISPATCH_CONSUMERS=["nix-darwin"]` repo variable set on `dryvist/nix-home`
- [ ] After next nix-home release: confirm `nix-darwin` receives the dispatch
  and an `update-flake-input` job fires

Refs: dryvist/nix-ai#880 dryvist/nix-darwin#1188 dryvist/nix-claude-code#47

🤖 Generated with [Claude Code](https://claude.com/claude-code)