### PR TITLE
fix(aws): set --duration=14400 on av and avd aliases

### DIFF
--- a/modules/home-manager/zsh/aliases.nix
+++ b/modules/home-manager/zsh/aliases.nix
@@ -67,9 +67,9 @@
   #   av terraform -- terraform plan # Run terraform with specific profile
   #   avl                            # List all profiles in vault
   #   avd aws sts get-caller-identity # Quick check with default profile
-  av = "aws-vault exec"; # Execute command with profile credentials
+  av = "aws-vault exec --duration=14400"; # Execute command with profile credentials (4h session)
   avl = "aws-vault list"; # List profiles stored in vault
-  avd = "aws-vault exec default --"; # Execute with default profile
+  avd = "aws-vault exec --duration=14400 default --"; # Execute with default profile (4h session)
   ava = "aws-vault add"; # Add new profile credentials to vault
   avr = "aws-vault remove"; # Remove profile from vault
 


### PR DESCRIPTION
## Summary

- Adds `--duration=14400` (4-hour session) to both `av` and `avd` aliases
- Prevents repeated credential prompts when running long Terraform/AWS sessions

## Test plan

- [ ] `darwin-rebuild switch` and verify `alias av` shows `--duration=14400`
- [ ] Run `av <profile> -- aws sts get-caller-identity` and confirm 4h session token is issued