### PR TITLE
docs(copilot): drop model version number from comment

### DIFF
--- a/modules/home-manager/vscode/copilot-settings.nix
+++ b/modules/home-manager/vscode/copilot-settings.nix
@@ -149,7 +149,7 @@ _:
 
   # === MODEL SELECTION (Introduced February 2025) ===
   # Copilot CLI and VS Code now support model selection
-  # Including Claude Sonnet 4.5 in public preview
+  # Including Claude Sonnet in public preview
   # This is typically configured via the Copilot UI, not settings.json
 
   # === NOTES ===


### PR DESCRIPTION
Scrubs `Claude Sonnet 4.5` -> `Claude Sonnet` in the Copilot model-selection comment. Exact model versions churn too fast to keep accurate in comments; the family name is stable. Comment-only, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)