### PR TITLE
fix(zsh): use 4h unit in aws-vault duration aliases

### DIFF
--- a/modules/home-manager/zsh/aliases.nix
+++ b/modules/home-manager/zsh/aliases.nix
@@ -67,9 +67,9 @@
   #   av terraform -- terraform plan # Run terraform with specific profile
   #   avl                            # List all profiles in vault
   #   avd aws sts get-caller-identity # Quick check with default profile
-  av = "aws-vault exec --duration=14400"; # Execute command with profile credentials (4h session)
+  av = "aws-vault exec --duration=4h"; # Execute command with profile credentials (4h session)
   avl = "aws-vault list"; # List profiles stored in vault
-  avd = "aws-vault exec --duration=14400 default --"; # Execute with default profile (4h session)
+  avd = "aws-vault exec --duration=4h default --"; # Execute with default profile (4h session)
   ava = "aws-vault add"; # Add new profile credentials to vault
   avr = "aws-vault remove"; # Remove profile from vault
 


### PR DESCRIPTION
## Summary

- `--duration=14400` → `--duration=4h` in both `av` and `avd` aliases
- `aws-vault` requires a time unit in the duration flag; bare integers cause `time: missing unit in duration` errors

## Test plan

- [ ] `darwin-rebuild switch` and confirm `av tf-proxmox --no-session -- ...` runs without the duration error