### PR TITLE
chore(git): ignore native AI worktree dirs globally

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Cross-platform home-manager modules for development environment tools.
 
 1. **Flakes-only**: Never use `nix-env` or imperative Nix commands
 2. **Cross-platform**: Modules must work on Darwin and Linux (4 systems)
-3. **Worktrees required**: Run `/init-worktree` before any work
+3. **Worktrees required**: work in a worktree before any changes
 4. **No direct main commits**: Always use feature branches
 
 ## Build Validation

--- a/modules/home-manager/git/config.nix
+++ b/modules/home-manager/git/config.nix
@@ -11,6 +11,13 @@
 {
   enable = true;
 
+  # Global ignore patterns (written to the XDG global excludes file).
+  # AI tools create native worktrees in their own dotdirs; never track them.
+  ignores = [
+    ".claude/worktrees/"
+    ".gemini/worktrees/"
+  ];
+
   # GPG signing configuration
   # NOTE: Key ID is a public identifier, not the private key (safe to commit)
   signing = {


### PR DESCRIPTION
## What
- `modules/home-manager/git/config.nix`: add `programs.git.ignores = [ ".claude/worktrees/" ".gemini/worktrees/" ]` so native AI-tool worktrees never show as untracked in any repo (= Phase 4 of the migration; one global entry instead of 49 per-repo .gitignore edits).
- `CLAUDE.md`: drop the stale `/init-worktree` command reference (replaced by the generic "work in a worktree" guardrail).

## Why
Part of #671 — migrating to normal clones with native AI-tool worktrees.

Refs: dryvist/ai-assistant-instructions#671

🤖 Generated with [Claude Code](https://claude.com/claude-code)