### PR TITLE
feat(packages): add awscli2

### DIFF
--- a/modules/common/packages.nix
+++ b/modules/common/packages.nix
@@ -116,6 +116,7 @@ lib.optionals pkgs.stdenv.isLinux [
   bws # Bitwarden Secrets Manager CLI (for machine secrets)
   doppler # Doppler secrets manager CLI (for CI/CD and team secrets)
   aws-vault # AWS credential management — session credentials backed by the OS keychain/credential store (used by av/avl/avd/ava/avr aliases)
+  awscli2 # AWS CLI v2 — provides the `aws` command
 
   # ==========================================================================
   # Remote Shell


### PR DESCRIPTION
## Summary

- Adds `awscli2` to `modules/common/packages.nix` in the Security & Credential Management section
- Fixes `zsh: command not found: aws` — `aws-vault` was installed but the AWS CLI binary itself was missing
- Per nix-package-placement rule: user dev tools and credentials belong in nix-home `home.packages`

## Changes

- `modules/common/packages.nix`: add `awscli2` alongside `aws-vault`

## Test Plan

- [ ] `darwin-rebuild switch` on consuming machine
- [ ] `aws --version` returns `aws-cli/2.x.x`
- [ ] `aws-vault list` still works (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)