### PR TITLE
fix(ci): repoint shared reusable workflows to dryvist org

### DIFF
--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -78,19 +78,19 @@ jobs:
     # on a `needs:` of `Merge Gate` can queue forever with no terminal state,
     # which prevents `gate` from ever running and leaves required-status
     # absent. Opt into RunsOn only on workflows outside the gate path.
-    uses: JacobPEvans-personal/.github/.github/workflows/_nix-validate.yml@main
+    uses: dryvist/.github/.github/workflows/_nix-validate.yml@main
 
   markdown-lint:
     name: Markdown Lint
     needs: changes
     if: needs.changes.outputs.markdown == 'true'
-    uses: JacobPEvans-personal/.github/.github/workflows/_markdown-lint.yml@main
+    uses: dryvist/.github/.github/workflows/_markdown-lint.yml@main
 
   file-size:
     name: File Size
     needs: changes
     if: needs.changes.outputs.nix == 'true' || needs.changes.outputs.markdown == 'true'
-    uses: JacobPEvans-personal/.github/.github/workflows/_file-size.yml@main
+    uses: dryvist/.github/.github/workflows/_file-size.yml@main
 
   # ==========================================================================
   # MERGE GATE - The ONLY required check in branch protection

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -7,4 +7,4 @@ permissions:
 
 jobs:
   copilot-setup-steps:
-    uses: JacobPEvans-personal/.github/.github/workflows/_copilot-setup-steps.yml@main
+    uses: dryvist/.github/.github/workflows/_copilot-setup-steps.yml@main

--- a/.github/workflows/osv-scan.yml
+++ b/.github/workflows/osv-scan.yml
@@ -1,7 +1,7 @@
 # Periodic + per-PR OSV vulnerability scan.
 #
-# Inherits the centralized reusable workflow from JacobPEvans/.github.
-# Config: JacobPEvans/.github/osv-scanner.toml (org default) or local
+# Inherits the centralized reusable workflow from dryvist/.github.
+# Config: dryvist/.github/osv-scanner.toml (org default) or local
 # osv-scanner.toml in this repo (takes precedence).
 #
 # Make this a required check via branch protection on `main` after merge.
@@ -24,8 +24,8 @@ permissions:
 
 jobs:
   scan:
-    # SHA pin → JacobPEvans-personal/.github main as of 2026-05-20.
+    # SHA pin → dryvist/.github main as of 2026-06-12.
     # Bump intentionally when the upstream workflow changes.
-    uses: JacobPEvans-personal/.github/.github/workflows/_osv-scan.yml@a76cf8faec4ea24036c9042bf52d18b573f172ae
+    uses: dryvist/.github/.github/workflows/_osv-scan.yml@dcc5257e5a6a24cbb137ddbd12494d9d2bf615b1
     with:
       runner_label: ubuntu-latest

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,3 +1,9 @@
+// Canonical source: dryvist/.github root .markdownlint-cli2.yaml.
+// Delta from canon: MD013 tables:false + heading/code-block lengths set
+// (canon: tables:true, strict:true, no heading/code overrides), MD024
+// siblings_only:true (canon: strict default), MD060 disabled (nixpkgs
+// markdownlint-cli2 lags the rule), fix/gitignore enabled, and ignores
+// extend canon's CHANGELOG.md with .github/aw/**.
 {
   "config": {
     "default": true,


### PR DESCRIPTION
## Summary

- Swap the owner segment of every reusable-workflow `uses:` reference from `JacobPEvans-personal/.github` to `dryvist/.github`. GitHub Actions `uses:` does not follow account-rename redirects, and policy is that dryvist repos must never depend on `JacobPEvans-personal/*`.
- `ci-gate.yml`: `_nix-validate.yml@main`, `_markdown-lint.yml@main`, `_file-size.yml@main` (refs unchanged, gate structure untouched)
- `copilot-setup-steps.yml`: `_copilot-setup-steps.yml@main` — the dryvist hub copy is the live functional version (the personal hub one was a deprecated `if: false` stub); this caller passes no inputs/secrets, fully compatible
- `osv-scan.yml`: `_osv-scan.yml` re-pinned to dryvist/.github main (`dcc5257`) — the old SHA pin (`a76cf8f`) only exists in the personal hub's history
- Annotate `.markdownlint-cli2.jsonc` with its canonical source (dryvist/.github root `.markdownlint-cli2.yaml`) and the intentional deltas it carries (kept because it diverges from canon)

## Left as-is

- `gh-aw-pin-refresh.yml` still points at `JacobPEvans-personal/.github/.github/workflows/_gh-aw-pin-refresh.yml@main` — that reusable workflow does **not** exist in dryvist/.github yet, so repointing it would break the workflow. Needs the hub workflow migrated first.
- `repo-health-audit.md` `{{#import}}` references and `*.lock.yml` (gh-aw generated) — out of scope per policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)