### PR TITLE
feat(python): include PyYAML in shared environment

### DIFF
--- a/modules/common/packages.nix
+++ b/modules/common/packages.nix
@@ -172,6 +172,7 @@ lib.optionals pkgs.stdenv.isLinux [
   (python314.withPackages (ps: [
     ps.cryptography # Cryptographic recipes and primitives
     ps.pygithub # GitHub API v3 Python library
+    ps.pyyaml # YAML parser/emitter for Python automation
     # Claude document-skills dependencies
     ps.pandas # xlsx: data manipulation
     ps.openpyxl # xlsx: formulas and formatting


### PR DESCRIPTION
## Summary
- Make PyYAML available from the shared Python 3.14 environment.
- Let automation rely on `import yaml` instead of local zero-dependency parsers.

## Changes
- Add `ps.pyyaml` to `python314.withPackages` in `modules/common/packages.nix`.
- Keep the package sourced from nixpkgs; the resolved version is `6.0.3`.

## Test Plan
- `nix fmt`
- `nix flake check`
- `nix eval --raw --impure --expr 'let flake = builtins.getFlake (toString ./.); pkgs = import flake.inputs.nixpkgs { system = "aarch64-darwin"; overlays = [ flake.overlays.default ]; config.allowUnfree = true; }; in pkgs.python314Packages.pyyaml.version'` -> `6.0.3`
- `nix shell --impure --expr 'let flake = builtins.getFlake (toString ./.); pkgs = import flake.inputs.nixpkgs { system = "aarch64-darwin"; overlays = [ flake.overlays.default ]; config.allowUnfree = true; }; in pkgs.python314.withPackages (ps: [ ps.pyyaml ])' -c python -c 'import yaml; print(yaml.__version__)'` -> `6.0.3`