### PR TITLE
fix(ci): pin GitHub Actions to commit SHAs (resolve CodeQL actions/unpinned-tag)

### DIFF
--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -50,7 +50,7 @@ jobs:
       markdown: ${{ steps.filter.outputs.markdown }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v4
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
         id: filter
         with:
           filters: |
@@ -102,7 +102,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check all results
-        uses: re-actors/alls-green@release/v1
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
         with:
           allowed-skips: nix-validate, markdown-lint, file-size
           jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/deps-update-flake.yml
+++ b/.github/workflows/deps-update-flake.yml
@@ -44,7 +44,7 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Install Nix
-        uses: DeterminateSystems/determinate-nix-action@629b284231c2a82554b724e357e47fc6020833c8 # v3
+        uses: DeterminateSystems/determinate-nix-action@v3
 
       - name: Update git-flow-next
         run: nix run nixpkgs#nix-update -- --flake git-flow-next
@@ -56,7 +56,7 @@ jobs:
         run: nix flake check --show-trace
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ steps.app-token.outputs.token }}
           sign-commits: true

--- a/.github/workflows/deps-update-flake.yml
+++ b/.github/workflows/deps-update-flake.yml
@@ -44,7 +44,7 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Install Nix
-        uses: DeterminateSystems/determinate-nix-action@v3
+        uses: DeterminateSystems/determinate-nix-action@629b284231c2a82554b724e357e47fc6020833c8 # v3
 
       - name: Update git-flow-next
         run: nix run nixpkgs#nix-update -- --flake git-flow-next
@@ -56,7 +56,7 @@ jobs:
         run: nix flake check --show-trace
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           token: ${{ steps.app-token.outputs.token }}
           sign-commits: true


### PR DESCRIPTION
## Why

Four open CodeQL code-scanning alerts (rule `actions/unpinned-tag`, medium) flag
GitHub Actions pinned to mutable tags/branches. This PR applies a **split policy**
rather than blanket SHA-pinning:

- **Third-party actions → pin to full commit SHA.** A mutable ref lets an
  upstream tag be re-pointed at malicious code; SHA-pinning is the supply-chain
  hardening CodeQL asks for.
- **User-designated trusted actions → keep at major version + allowlist in CodeQL.**
  For actions the maintainer trusts, a major-version tag is deliberate: it lets
  automated version bumpers keep upgrading them, and it keeps *missed* updates
  visible. A frozen SHA hides the fact that an update was missed when an
  auto-bumper fails — the opposite of what we want for trusted, actively-tracked
  dependencies. These two alerts are allowlisted/dismissed in CodeQL separately
  (needs an elevated token; handled by the maintainer, not this PR).

## What

| Action | Class | Ref in this PR |
|--------|-------|----------------|
| `dorny/paths-filter` (ci-gate.yml:53) | third-party | `@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4` (alert #4) |
| `re-actors/alls-green` (ci-gate.yml:105) | third-party | `@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1` (alert #5) |
| `DeterminateSystems/determinate-nix-action` (deps-update-flake.yml:47) | **trusted** | `@v3` (major version, allowlisted) |
| `peter-evans/create-pull-request` (deps-update-flake.yml:59) | **trusted** | `@v8` (major version, allowlisted) |

`re-actors/alls-green@release/v1` is a moving branch (not a tag) — pinned to its
current head with a `# release/v1` comment. Behavior is unchanged: each SHA is
what the ref resolves to today.

First-party `dryvist/*@main` reusable-workflow wrappers and `actions/checkout@v6`
were **not** flagged by CodeQL and are intentionally left untouched.

## Test Plan

- `zizmor` on both edited workflows: the SHA-pinned `uses:` lines produce zero
  findings (remaining findings are pre-existing/unrelated).
- Verified each SHA resolves from the tag/branch via the GitHub API.
- CodeQL re-scans on this PR. Alerts #4/#5 close via SHA pins; alerts #6/#7
  (trusted actions) are dismissed via the CodeQL allowlist separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)