### PR TITLE
feat(profiles): gate aws-config keychain generator behind server preset

### DIFF
--- a/modules/home-manager/common.nix
+++ b/modules/home-manager/common.nix
@@ -135,7 +135,9 @@ in
         export PATH="$HOME/.local/bin:$PATH"
 
         # --- Shell modules ---
-        ${lib.optionalString pkgs.stdenv.isDarwin "source ${awsConfig.initScript}"}
+        ${lib.optionalString (
+          pkgs.stdenv.isDarwin && features.awsConfig.enable
+        ) "source ${awsConfig.initScript}"}
         source ${./zsh/git-functions.zsh}
         source ${./zsh/docker-functions.zsh}
         source ${./zsh/process-cleanup.zsh}

--- a/modules/home-manager/profiles/default.nix
+++ b/modules/home-manager/profiles/default.nix
@@ -51,6 +51,7 @@ in
       googleWorkspace.enable = mkFeature "Google Workspace CLIs (gmailctl, rclone, gdrive3)";
       sessionLogging.enable = mkFeature "terminal session logging via script(1)";
       pinentryGui.enable = mkFeature "GUI pinentry (pinentry-mac); disable for headless TTY pinentry";
+      awsConfig.enable = mkFeature "AWS ~/.aws/config generation from the macOS Keychain at shell init";
     };
   };
 
@@ -64,5 +65,6 @@ in
     googleWorkspace.enable = lib.mkDefault workstation;
     sessionLogging.enable = lib.mkDefault workstation;
     pinentryGui.enable = lib.mkDefault workstation;
+    awsConfig.enable = lib.mkDefault workstation;
   };
 }


### PR DESCRIPTION
## Why

The aws-config generator (`aws/ensure-config.zsh`, `_aws_config_ensure`) reads `AWS_ACCOUNT_ID` from the macOS Keychain at shell init. It was sourced on **every** Darwin host (gated only on `pkgs.stdenv.isDarwin`), so a headless macOS server — the Mac Studio `jevans-ms`, which has no `automation.keychain-db` — printed `aws-config: keychain lookup failed for AWS_ACCOUNT_ID` on every login shell.

A headless inference server has no use for `~/.aws/config` (those are the personal aws-vault developer profiles); its real AWS need (route53 ACME for the llm-gate) is served by sops-rendered secrets, not this file.

## What

Add an `awsConfig` `home-profile` feature flag — default **on** for `workstation`, **off** for `server`, overridable per host — mirroring the existing `sessionLogging` gate, and AND it into the `source ${awsConfig.initScript}` line in `common.nix`. The Linux `~/.aws/config` fallback (`awsConfig.files`) is untouched.

## Verification

- `nix flake check` passes.
- The gate mirrors `sessionLogging.enable` exactly (feature flag + `lib.mkDefault workstation` + `lib.optionalString` on the source line).
- End-to-end: consumed by nix-darwin; a `jevans-ms` rebuild after bumping the input will confirm the login error is gone (server preset omits the source), while workstation output is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)