### PR TITLE
fix: nixfmt-rfc-style -> nixfmt (nixpkgs deprecation alias)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -109,7 +109,7 @@
         {
           default = pkgs.mkShell {
             packages = with pkgs; [
-              nixfmt-rfc-style
+              nixfmt
               statix
               deadnix
               treefmt

--- a/lib/checks.nix
+++ b/lib/checks.nix
@@ -9,13 +9,13 @@
   overlay,
 }:
 {
-  # Check Nix formatting with nixfmt-rfc-style
+  # Check Nix formatting with nixfmt
   # Uses treefmt configured with nixfmt formatter
   # Copy source to writable $TMPDIR since treefmt needs to write temp files
   formatting =
     pkgs.runCommand "check-formatting"
       {
-        nativeBuildInputs = [ pkgs.nixfmt-rfc-style ];
+        nativeBuildInputs = [ pkgs.nixfmt ];
       }
       ''
         cp -r ${src} $TMPDIR/src

--- a/modules/common/packages/core.nix
+++ b/modules/common/packages/core.nix
@@ -74,7 +74,7 @@ with pkgs;
   markdownlint-cli2 # Markdown linter (README, docs exist everywhere)
 
   # Nix (2025 official tooling)
-  nixfmt-rfc-style # Official Nix formatter (RFC 166, v1.1.0+)
+  nixfmt # Official Nix formatter (RFC 166, v1.1.0+; formerly pkgs.nixfmt-rfc-style)
   statix # Nix linter - catches anti-patterns
   deadnix # Find unused code in .nix files
   treefmt # Multi-language formatter runner

--- a/modules/precommit-tools/default.nix
+++ b/modules/precommit-tools/default.nix
@@ -48,11 +48,11 @@
         }
         {
           id = "nix-fmt-check";
-          name = "Nix formatting (nixfmt-rfc-style)";
+          name = "Nix formatting (nixfmt)";
           command = "nixfmt --check";
           description = "Formats Nix code to RFC style";
           fileTypes = [ "nix" ];
-          package = "pkgs.nixfmt-rfc-style";
+          package = "pkgs.nixfmt";
         }
         {
           id = "markdownlint-cli2";
@@ -191,10 +191,10 @@
       language = "Rust";
     };
     nixfmtRfcStyle = {
-      name = "nixfmt-rfc-style";
+      name = "nixfmt";
       description = "Opinionated Nix formatter following RFC style";
       homepage = "https://github.com/NixOS/nixfmt";
-      package = "pkgs.nixfmt-rfc-style";
+      package = "pkgs.nixfmt";
       language = "Rust";
     };
     markdownlintCli2 = {


### PR DESCRIPTION
`pkgs.nixfmt-rfc-style` now aliases `pkgs.nixfmt` and emits `evaluation warning: nixfmt-rfc-style is now the same as pkgs.nixfmt which should be used instead`. The `home.packages` entry (`modules/common/packages/core.nix`) is in the home-manager closure, so this warning fires on **every consuming `darwin-rebuild`** (observed on jevans-mbp + jevans-ms).

Swap all references to `pkgs.nixfmt`:
- `modules/common/packages/core.nix` — the `home.packages` entry (the rebuild-visible source).
- `flake.nix` devShell, `lib/checks.nix` formatting check, `modules/precommit-tools/default.nix` package strings.

The `nixfmt --check` command was already using `nixfmt`; this aligns the package references. Part of a multi-repo sweep to clear every rebuild warning. `nix flake check` passes.