### PR TITLE
feat(darwin): set HF_HOME on all Macs, not just workstations

### DIFF
--- a/modules/home-manager/common.nix
+++ b/modules/home-manager/common.nix
@@ -79,10 +79,15 @@ in
       GIT_HOME_PUBLIC = "${config.home.homeDirectory}/git/public";
       GIT_HOME_PRIVATE = "${config.home.homeDirectory}/git/dryvist-private";
     }
-    // lib.optionalAttrs (pkgs.stdenv.isDarwin && config.home-profile.preset == "workstation") {
-      # Workstation-only: external HuggingFace volume + local build-cache tuning.
-      # A headless server has neither the /Volumes mount nor the sccache workload.
+    // lib.optionalAttrs pkgs.stdenv.isDarwin {
+      # Every Mac keeps its HuggingFace cache on a dedicated APFS volume (created
+      # by nix-darwin apfs-volumes, identical across hosts) so the CLI, the model
+      # server, and disk cleanup all reference one path per machine.
       HF_HOME = "/Volumes/HuggingFace";
+    }
+    // lib.optionalAttrs (pkgs.stdenv.isDarwin && config.home-profile.preset == "workstation") {
+      # Workstation-only: local build-cache tuning; a headless server has no
+      # sccache workload.
       SCCACHE_CACHE_SIZE = "5G";
     };
 


### PR DESCRIPTION
## Summary

Un-gate `HF_HOME` from the `workstation` preset so every Mac points its HuggingFace cache at the dedicated `/Volumes/HuggingFace` APFS volume (created identically by nix-darwin `apfs-volumes`).

## Why

Previously `HF_HOME` was set only on workstations. On a headless server it was unset, so the `hf` CLI defaulted to `~/.cache/huggingface` while the model server read from its configured volume — the two could disagree. Setting `HF_HOME` on all Darwin hosts makes the CLI, the model server, and disk-usage cleanup reference one path per machine. `SCCACHE_CACHE_SIZE` stays workstation-only (no sccache workload on a server).

## Test Plan

- `nix fmt` clean.
- Pairs with nix-darwin PR that creates `/Volumes/HuggingFace` and the nix-ai PR that points the server's `mlx.huggingFaceHome` at the same volume.