### PR TITLE
chore(secrets): SOPS rules + encrypted zsh-env

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,0 +1,5 @@
+creation_rules:
+  - path_regex: secrets/.*\.yaml$
+    key_groups:
+      - age:
+          - age1y0jvtlp2ac8fwwvh2nzm88ehye74jlseywjrjcjqll7u8vycsedq788tp9

--- a/secrets/zsh-env.yaml
+++ b/secrets/zsh-env.yaml
@@ -1,0 +1,16 @@
+alias_vars: ENC[AES256_GCM,data:nmxqG6X9iRim55Cc8KY0T/gLUxaywGgvF4lZCYHDlNqphHGGl4tYCaraWyUM4iMrFNO1fYNOMIPPTxErRYMAia72sahv2nv9N6m8IUxeU/PyWDFCGkQ8cfntrCQtRRbOOIIT3mzV8vDVoPR9zHfM3wH9VlhK6vicMCo8yVh8hJuiQBAkCSFjA3sVgySHPbFrR+vdKCopaOfndljwIfre//y8X22xIc92Jcgpf2oeWcEFCLmKoVDRrg==,iv:ArxconJlj9FluZsJFc4JoAqDqau5Rgyw4BjKkoWCdnE=,tag:j5+jSbJj/Re5MSj3xhiWrQ==,type:str]
+sops:
+    age:
+        - recipient: age1y0jvtlp2ac8fwwvh2nzm88ehye74jlseywjrjcjqll7u8vycsedq788tp9
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA4QXBOOXEydHhCbHBGbC85
+            WUhFOWVoeERUcDdRSzg3a1oxYzdRVW8xckQ0CkpKd2lzS0p3eHRZNlVrTnRZN05I
+            OVM0S3ZmYzRjbUhXdEZaZ1lPajJDT2sKLS0tIHdtUDRmVWx2R09HU0dGMHFwM3JJ
+            SGhpRTR5S1ZFRURCTVdrZ01DaGVoTW8Ks0b0IMYrENzLBKPJyInEe0GHXxAYgfv3
+            D6yvC3GotquGlQ3o1NbNN7mcTpDIi4694pC7oPIg4bPHV85JMrFX7w==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-04-19T14:39:09Z"
+    mac: ENC[AES256_GCM,data:l+cJ1ZsmxdlMrg6B0RD++LXxT/xKG5QcBLyELuR+oa9r2lc9iOkErQfyn4Ufz422/P4363w3FIZgMC5FBUPSGlnPE8cwvaahEXYiSGuibA8nXkBmAP7/89Nw5jZsWR/0Hsw2i+M1VCoqTPuKKvPN/0knxnvVnNa3wXIe/I7ugH4=,iv:hCY4YGMHQGxreH4jASFn0vyCm02Vakojs4+k8qsoDlc=,tag:p8U3b7y3jWhmv4bdPBRjkw==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.12.2


### PR DESCRIPTION
Rescue of uncommitted SOPS config.

- `.sops.yaml` — age public recipient + creation rules (no private material).
- `secrets/zsh-env.yaml` — verified SOPS-encrypted ciphertext (`ENC[AES256_GCM...]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)