### PR TITLE
feat(zsh): d-r rebuilds from the canonical remote flake

### DIFF
--- a/modules/home-manager/zsh/aliases.nix
+++ b/modules/home-manager/zsh/aliases.nix
@@ -36,8 +36,11 @@
   # ===========================================================================
   # REQUIRES SUDO: darwin-rebuild modifies system-level configurations
   # This activates both system (nix-darwin) and user (home-manager) configs
-  # Usage: d-r            # darwin-rebuild switch (standard rebuild)
-  d-r = "sudo darwin-rebuild switch --flake .";
+  # Pulls the canonical remote flake so a rebuild never depends on local
+  # checkout state; darwin-rebuild resolves darwinConfigurations.<hostName>
+  # from the machine's hostname, so one alias serves every host.
+  # Usage: d-r            # darwin-rebuild switch from github:dryvist/nix-darwin
+  d-r = "sudo darwin-rebuild switch --flake github:dryvist/nix-darwin --refresh --no-write-lock-file --print-build-logs";
 
   # NO SUDO: Updates flake.lock to latest nixpkgs (must commit before d-r)
   # Usage: nf-u            # update flake in current directory


### PR DESCRIPTION
The `d-r` alias ran `darwin-rebuild switch --flake .` — dependent on whatever local checkout (and its dirty/stale state) the shell was in.

It now runs:

```
sudo darwin-rebuild switch --flake github:dryvist/nix-darwin --refresh --no-write-lock-file --print-build-logs
```

- `--refresh` bypasses the flake eval cache so it always fetches current `main`.
- `--no-write-lock-file` because a remote flake ref can't (and shouldn't) update a local lock.
- darwin-rebuild resolves `darwinConfigurations.<hostName>` from the machine hostname (`jevans-mbp` / `jevans-ms`), so one alias serves every host — verified both attrs are keyed by hostName in `lib/hosts.nix`.
- Verified live: the exact command ran successfully on jevans-ms (user-run, no password prompt beyond sudo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011cXrVfFqrTQdYqZvAHpE8j