### PR TITLE
chore(renovate): use org renovate-nix preset

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,10 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended",
-    "local>dryvist/.github",
-  ],
-  "nix": {
-    "enabled": true,
-  },
+  "extends": ["local>dryvist/.github:renovate-nix"]
 }


### PR DESCRIPTION
Switches this nix repo to the shared `local>dryvist/.github:renovate-nix` preset, which bundles the org default policy with the native `nix` manager. Replaces the previous `config:recommended` + `local>dryvist/.github` + inline `nix.enabled` (and any redundant `:dependencyDashboard`). No behavioral change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CB5heppQHhv8xE1XWeeFVA