### PR TITLE
feat(tmux): mobile/Termius ergonomics

### DIFF
--- a/modules/home-manager/darwin/default.nix
+++ b/modules/home-manager/darwin/default.nix
@@ -11,5 +11,6 @@
 {
   imports = [
     ./nix-activation-recovery.nix
+    ./tmux-session-autostart.nix
   ];
 }

--- a/modules/home-manager/darwin/tmux-session-autostart.nix
+++ b/modules/home-manager/darwin/tmux-session-autostart.nix
@@ -1,0 +1,46 @@
+# Tmux "cc" Session Autostart
+#
+# A reboot always kills the tmux server (it's just a process) — any session
+# running on it, and Termius' `tmux attach -t cc` startup command, dies with
+# it. This LaunchAgent recreates an empty "cc" session at every login so it's
+# always there to attach to, from Ghostty on the Mac or Termius on mobile.
+
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.tmux-session-autostart;
+  tmux = "${config.programs.tmux.package}/bin/tmux";
+
+  ensureSessionScript = pkgs.writeShellScript "tmux-cc-session-autostart" ''
+    ${tmux} has-session -t cc 2>/dev/null || ${tmux} new-session -d -s cc
+  '';
+in
+{
+  options.programs.tmux-session-autostart = {
+    enable = lib.mkEnableOption "auto-create the tmux \"cc\" session at login";
+  };
+
+  config = lib.mkIf cfg.enable {
+    launchd.agents.tmux-cc-session = {
+      enable = true;
+      config = {
+        Label = "dev.local.tmux-cc-session";
+        ProgramArguments = [ "${ensureSessionScript}" ];
+
+        # Recreate at every login; the script itself is idempotent (has-session
+        # check) so RunAtLoad firing more than once (e.g. a fast relaunch) is
+        # harmless.
+        RunAtLoad = true;
+        KeepAlive = false;
+
+        StandardOutPath = "/tmp/tmux-cc-session-autostart-stdout.log";
+        StandardErrorPath = "/tmp/tmux-cc-session-autostart-stderr.log";
+      };
+    };
+  };
+}

--- a/modules/home-manager/tmux.nix
+++ b/modules/home-manager/tmux.nix
@@ -70,6 +70,20 @@ in
       # True color support (Tc is the tmux-specific true color flag)
       set -ga terminal-overrides ",*256color*:Tc"
 
+      # --- Mobile / Termius ergonomics ---
+      # OSC52: text yanked in tmux lands in the phone's clipboard over SSH.
+      set -g set-clipboard on
+      # Phone soft-keyboards are slow; widen the repeat window so prefix+H/J/K/L
+      # pane resizes chain without re-pressing the prefix each time.
+      set -g repeat-time 600
+      # The Termius keyboard bar covers the bottom rows — keep the status line
+      # (and its window list) visible at the top instead.
+      set -g status-position top
+      # A closed session drops you to another instead of killing the SSH attach.
+      set -g detach-on-destroy off
+      # Match pane numbering to the base-1 window index for muscle-memory parity.
+      setw -g pane-base-index 1
+
       # Minimal status bar
       set -g status-left " [#S] "
       set -g status-right " #H  %H:%M "


### PR DESCRIPTION
## What

Two mobile/Termius-related changes to `modules/home-manager/tmux.nix` and a new `darwin/` LaunchAgent module.

### 1. Mobile ergonomics (tmux.nix)

Five phone-friendly options layered onto the existing config for attaching from **Termius** over SSH. No plugin changes, no change to the desktop workflow.

| Option | Why (mobile) |
| --- | --- |
| `set-clipboard on` | OSC52 — text yanked in tmux lands in the phone clipboard over SSH |
| `repeat-time 600` | slow soft-keyboards can still chain `prefix`+H/J/K/L pane resizes |
| `status-position top` | Termius' on-screen key bar covers the bottom rows; keep the status line + window list visible |
| `detach-on-destroy off` | closing a session drops to another instead of killing the SSH attach |
| `pane-base-index 1` | parity with the existing base-1 window index |

### 2. Auto-recreate the `cc` session at login (new: `tmux-session-autostart.nix`)

A reboot always kills the tmux server — the `cc` session (and Termius' `tmux attach -t cc` startup command) dies with it until someone notices and recreates it by hand. Adds a LaunchAgent, following the existing `nix-activation-recovery.nix` pattern (`mkEnableOption` + `launchd.agents`), that idempotently recreates an empty `cc` session at every login.

Opt-in: `programs.tmux-session-autostart.enable = true;` — set in the consuming nix-darwin host config (not this repo). **Follow-up needed in nix-darwin** to actually enable it; this PR only adds the module.

## Validation

`nix fmt` clean, `nix flake check` green on both commits. Options/module are valid on tmux 3.6a and match the existing LaunchAgent convention; `extraConfig`/scripts are string literals so they cannot break module evaluation.

## Not in scope

Prefix/keymode/plugins unchanged. Enabling the new LaunchAgent on any given host — that's a nix-darwin host-config change, tracked separately.