### PR TITLE
fix: point GIT_HOME_PRIVATE at the new private workspace root

### DIFF
--- a/modules/home-manager/common.nix
+++ b/modules/home-manager/common.nix
@@ -77,7 +77,7 @@ in
       # instead of hard-coding /Users/<you>/git/...
       GIT_HOME = "${config.home.homeDirectory}/git";
       GIT_HOME_PUBLIC = "${config.home.homeDirectory}/git/public";
-      GIT_HOME_PRIVATE = "${config.home.homeDirectory}/git/dryvist-private";
+      GIT_HOME_PRIVATE = "${config.home.homeDirectory}/git/private";
     }
     // lib.optionalAttrs pkgs.stdenv.isDarwin {
       # Every Mac keeps its HuggingFace cache on a dedicated APFS volume (created


### PR DESCRIPTION
## Summary

The workspace reorg (2026-07-10) moved private repos from `~/git/dryvist-private/<repo>` to `~/git/private/<owner>/<family>/<repo>`. This updates the `GIT_HOME_PRIVATE` session variable to the new root.

## Changes

- `modules/home-manager/common.nix`: `GIT_HOME_PRIVATE` now points at `~/git/private` (was `~/git/dryvist-private`).

## Test Plan

- `nix flake check` passes locally (aarch64-darwin).
- After merge + `darwin-rebuild switch`, a fresh shell reports `GIT_HOME_PRIVATE=$HOME/git/private`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NopNWJek64JUnQrD3Xhwrw