### PR TITLE
chore: promote develop to main

### DIFF
--- a/modules/home-manager/aws/config.nix
+++ b/modules/home-manager/aws/config.nix
@@ -62,14 +62,36 @@ let
   # base identity each assumes from (no MFA). New projects live under `tofu`;
   # legacy projects stay under `terraform` until migrated.
   tfProjects = import ./tf-projects.nix;
+
+  # Projects migrated off the static aws-vault base key onto OpenBao's AWS
+  # secrets engine (dynamic STS, assumed_role). A project listed here gets a
+  # `credential_process` profile instead of source_profile/role_arn — the
+  # wrapper (nix-darwin `openbao-aws-creds`, on PATH system-wide) reads the
+  # terraform-apply AppRole from openbao.keychain-db and mints short-lived
+  # creds on demand, so no static AWS key exists on the machine. Move a
+  # project here once its aws/roles/<name> exists in OpenBao.
+  openbaoStsProjects = {
+    proxmox = "openbao-aws-creds tf-proxmox";
+  };
+
   mkTfProfiles =
     base: names:
-    map (name: {
-      name = "tf-${name}";
-      comment = "tf-${name}: assumes role/tf-${name} via the ${base} base identity";
-      source_profile = base;
-      role_arn = "arn:aws:iam::${accountIdPlaceholder}:role/tf-${name}";
-    }) names;
+    map (
+      name:
+      if openbaoStsProjects ? ${name} then
+        {
+          name = "tf-${name}";
+          comment = "tf-${name}: dynamic STS creds from OpenBao (credential_process, no static key)";
+          credential_process = openbaoStsProjects.${name};
+        }
+      else
+        {
+          name = "tf-${name}";
+          comment = "tf-${name}: assumes role/tf-${name} via the ${base} base identity";
+          source_profile = base;
+          role_arn = "arn:aws:iam::${accountIdPlaceholder}:role/tf-${name}";
+        }
+    ) names;
   tfProfiles =
     (mkTfProfiles "terraform" tfProjects.terraform) ++ (mkTfProfiles "tofu" tfProjects.tofu);
 
@@ -89,8 +111,16 @@ let
         source_profile = ${profile.source_profile}
         role_arn = ${profile.role_arn}
       '';
+      credProcess = ''
+        credential_process = ${profile.credential_process}
+      '';
     in
-    if profile ? role_arn && profile ? source_profile then base + role else base;
+    if profile ? credential_process then
+      base + credProcess
+    else if profile ? role_arn && profile ? source_profile then
+      base + role
+    else
+      base;
 
   configContent = builtins.concatStringsSep "\n\n" (map generateProfile profiles);
   configContentFile = pkgs.writeText "aws-config-template" configContent;

--- a/modules/home-manager/common.nix
+++ b/modules/home-manager/common.nix
@@ -77,7 +77,7 @@ in
       # instead of hard-coding /Users/<you>/git/...
       GIT_HOME = "${config.home.homeDirectory}/git";
       GIT_HOME_PUBLIC = "${config.home.homeDirectory}/git/public";
-      GIT_HOME_PRIVATE = "${config.home.homeDirectory}/git/dryvist-private";
+      GIT_HOME_PRIVATE = "${config.home.homeDirectory}/git/private";
     }
     // lib.optionalAttrs pkgs.stdenv.isDarwin {
       # Every Mac keeps its HuggingFace cache on a dedicated APFS volume (created

--- a/modules/home-manager/darwin/default.nix
+++ b/modules/home-manager/darwin/default.nix
@@ -11,5 +11,6 @@
 {
   imports = [
     ./nix-activation-recovery.nix
+    ./tmux-session-autostart.nix
   ];
 }

--- a/modules/home-manager/darwin/tmux-session-autostart.nix
+++ b/modules/home-manager/darwin/tmux-session-autostart.nix
@@ -38,8 +38,10 @@ in
         RunAtLoad = true;
         KeepAlive = false;
 
-        StandardOutPath = "/tmp/tmux-cc-session-autostart-stdout.log";
-        StandardErrorPath = "/tmp/tmux-cc-session-autostart-stderr.log";
+        # ~/Library/Logs, not /tmp: a world-writable dir with static names
+        # invites symlink attacks, and the logs vanish on reboot.
+        StandardOutPath = "${config.home.homeDirectory}/Library/Logs/tmux-cc-session-autostart.log";
+        StandardErrorPath = "${config.home.homeDirectory}/Library/Logs/tmux-cc-session-autostart.error.log";
       };
     };
   };

--- a/modules/home-manager/darwin/tmux-session-autostart.nix
+++ b/modules/home-manager/darwin/tmux-session-autostart.nix
@@ -1,0 +1,46 @@
+# Tmux "cc" Session Autostart
+#
+# A reboot always kills the tmux server (it's just a process) — any session
+# running on it, and Termius' `tmux attach -t cc` startup command, dies with
+# it. This LaunchAgent recreates an empty "cc" session at every login so it's
+# always there to attach to, from Ghostty on the Mac or Termius on mobile.
+
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.tmux-session-autostart;
+  tmux = "${config.programs.tmux.package}/bin/tmux";
+
+  ensureSessionScript = pkgs.writeShellScript "tmux-cc-session-autostart" ''
+    ${tmux} has-session -t cc 2>/dev/null || ${tmux} new-session -d -s cc
+  '';
+in
+{
+  options.programs.tmux-session-autostart = {
+    enable = lib.mkEnableOption "auto-create the tmux \"cc\" session at login";
+  };
+
+  config = lib.mkIf cfg.enable {
+    launchd.agents.tmux-cc-session = {
+      enable = true;
+      config = {
+        Label = "dev.local.tmux-cc-session";
+        ProgramArguments = [ "${ensureSessionScript}" ];
+
+        # Recreate at every login; the script itself is idempotent (has-session
+        # check) so RunAtLoad firing more than once (e.g. a fast relaunch) is
+        # harmless.
+        RunAtLoad = true;
+        KeepAlive = false;
+
+        StandardOutPath = "/tmp/tmux-cc-session-autostart-stdout.log";
+        StandardErrorPath = "/tmp/tmux-cc-session-autostart-stderr.log";
+      };
+    };
+  };
+}

--- a/modules/home-manager/tmux.nix
+++ b/modules/home-manager/tmux.nix
@@ -70,6 +70,20 @@ in
       # True color support (Tc is the tmux-specific true color flag)
       set -ga terminal-overrides ",*256color*:Tc"
 
+      # --- Mobile / Termius ergonomics ---
+      # OSC52: text yanked in tmux lands in the phone's clipboard over SSH.
+      set -g set-clipboard on
+      # Phone soft-keyboards are slow; widen the repeat window so prefix+H/J/K/L
+      # pane resizes chain without re-pressing the prefix each time.
+      set -g repeat-time 600
+      # The Termius keyboard bar covers the bottom rows — keep the status line
+      # (and its window list) visible at the top instead.
+      set -g status-position top
+      # A closed session drops you to another instead of killing the SSH attach.
+      set -g detach-on-destroy off
+      # Match pane numbering to the base-1 window index for muscle-memory parity.
+      setw -g pane-base-index 1
+
       # Minimal status bar
       set -g status-left " [#S] "
       set -g status-right " #H  %H:%M "


### PR DESCRIPTION
## Summary
Promotes the current state of `develop` to `main`.

## Commits being promoted

- e90b0d9 feat(tmux): mobile/Termius ergonomics (#365)
- 5545404 fix: point GIT_HOME_PRIVATE at the new private workspace root (#366)

## Notes
- Merge commit only — `main` ruleset bans squash and rebase.
- Merging triggers release-please on `main`; it owns version bump and CHANGELOG.
