### PR TITLE
feat(aws): serve tf-proxmox creds via OpenBao credential_process

### DIFF
--- a/modules/home-manager/aws/config.nix
+++ b/modules/home-manager/aws/config.nix
@@ -62,14 +62,36 @@ let
   # base identity each assumes from (no MFA). New projects live under `tofu`;
   # legacy projects stay under `terraform` until migrated.
   tfProjects = import ./tf-projects.nix;
+
+  # Projects migrated off the static aws-vault base key onto OpenBao's AWS
+  # secrets engine (dynamic STS, assumed_role). A project listed here gets a
+  # `credential_process` profile instead of source_profile/role_arn — the
+  # wrapper (nix-darwin `openbao-aws-creds`, on PATH system-wide) reads the
+  # terraform-apply AppRole from openbao.keychain-db and mints short-lived
+  # creds on demand, so no static AWS key exists on the machine. Move a
+  # project here once its aws/roles/<name> exists in OpenBao.
+  openbaoStsProjects = {
+    proxmox = "openbao-aws-creds tf-proxmox";
+  };
+
   mkTfProfiles =
     base: names:
-    map (name: {
-      name = "tf-${name}";
-      comment = "tf-${name}: assumes role/tf-${name} via the ${base} base identity";
-      source_profile = base;
-      role_arn = "arn:aws:iam::${accountIdPlaceholder}:role/tf-${name}";
-    }) names;
+    map (
+      name:
+      if openbaoStsProjects ? ${name} then
+        {
+          name = "tf-${name}";
+          comment = "tf-${name}: dynamic STS creds from OpenBao (credential_process, no static key)";
+          credential_process = openbaoStsProjects.${name};
+        }
+      else
+        {
+          name = "tf-${name}";
+          comment = "tf-${name}: assumes role/tf-${name} via the ${base} base identity";
+          source_profile = base;
+          role_arn = "arn:aws:iam::${accountIdPlaceholder}:role/tf-${name}";
+        }
+    ) names;
   tfProfiles =
     (mkTfProfiles "terraform" tfProjects.terraform) ++ (mkTfProfiles "tofu" tfProjects.tofu);
 
@@ -89,8 +111,16 @@ let
         source_profile = ${profile.source_profile}
         role_arn = ${profile.role_arn}
       '';
+      credProcess = ''
+        credential_process = ${profile.credential_process}
+      '';
     in
-    if profile ? role_arn && profile ? source_profile then base + role else base;
+    if profile ? credential_process then
+      base + credProcess
+    else if profile ? role_arn && profile ? source_profile then
+      base + role
+    else
+      base;
 
   configContent = builtins.concatStringsSep "\n\n" (map generateProfile profiles);
   configContentFile = pkgs.writeText "aws-config-template" configContent;


### PR DESCRIPTION
## What

Point the `tf-proxmox` AWS profile at the OpenBao `credential_process` wrapper
instead of a static `source_profile`/`role_arn`, so it sources short-lived STS
creds. Other `tf-*` profiles are unchanged.

## Changes

- **`modules/home-manager/aws/config.nix`** — add an `openbaoStsProjects` map
  (`proxmox = "openbao-aws-creds tf-proxmox"`). `mkTfProfiles`/`generateProfile`
  branch on membership: a mapped project renders a `credential_process` line; every
  other profile renders exactly as before.

## Notes

- The wrapper itself ships from the nix-darwin PR; the server-side engine + RBAC
  from ansible-proxmox-apps.
- Migrating another `tf-*` profile later is a one-line addition to the map.

## Test

Eval-rendered with stub pkgs: `[profile tf-proxmox]` emits
`credential_process = openbao-aws-creds tf-proxmox`; all other profiles are
byte-identical to before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gb6NwqwMGy3kW3Bf9kR13R
