### PR TITLE
fix(tmux-autostart): move launchd logs from /tmp to ~/Library/Logs

### DIFF
--- a/modules/home-manager/darwin/tmux-session-autostart.nix
+++ b/modules/home-manager/darwin/tmux-session-autostart.nix
@@ -38,8 +38,10 @@ in
         RunAtLoad = true;
         KeepAlive = false;
 
-        StandardOutPath = "/tmp/tmux-cc-session-autostart-stdout.log";
-        StandardErrorPath = "/tmp/tmux-cc-session-autostart-stderr.log";
+        # ~/Library/Logs, not /tmp: a world-writable dir with static names
+        # invites symlink attacks, and the logs vanish on reboot.
+        StandardOutPath = "${config.home.homeDirectory}/Library/Logs/tmux-cc-session-autostart.log";
+        StandardErrorPath = "${config.home.homeDirectory}/Library/Logs/tmux-cc-session-autostart.error.log";
       };
     };
   };


### PR DESCRIPTION
Addresses the review thread on promotion #367: launchd agent logs were written to world-writable `/tmp` with static filenames (predictable-path/symlink risk, lost on reboot). Moved to `~/Library/Logs/` per macOS convention, matching every other user agent in the nix stack.

Validation: `nix flake check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nw6KWXN6S7k13w2xAhRZb3