### PR TITLE
fix(tmux): robust autostart logging (log paths + PATH for run-shell hooks)

### DIFF
--- a/modules/home-manager/darwin/tmux-session-autostart.nix
+++ b/modules/home-manager/darwin/tmux-session-autostart.nix
@@ -38,8 +38,10 @@ in
         RunAtLoad = true;
         KeepAlive = false;
 
-        StandardOutPath = "/tmp/tmux-cc-session-autostart-stdout.log";
-        StandardErrorPath = "/tmp/tmux-cc-session-autostart-stderr.log";
+        # ~/Library/Logs, not /tmp: a world-writable dir with static names
+        # invites symlink attacks, and the logs vanish on reboot.
+        StandardOutPath = "${config.home.homeDirectory}/Library/Logs/tmux-cc-session-autostart.log";
+        StandardErrorPath = "${config.home.homeDirectory}/Library/Logs/tmux-cc-session-autostart.error.log";
       };
     };
   };

--- a/modules/home-manager/tmux.nix
+++ b/modules/home-manager/tmux.nix
@@ -9,7 +9,13 @@ let
   # Auto-start script shipped by the tmux-logging plugin itself — a vendored
   # script, not a custom one. A freshly created pane is never already logging,
   # so invoking the toggle once per new pane always STARTS logging.
-  tmuxLoggingToggle = "${pkgs.tmuxPlugins.logging}/share/tmux-plugins/logging/scripts/toggle_logging.sh";
+  #
+  # The plugin scripts shell out to bare `tmux`, but a run-shell hook inherits
+  # the tmux SERVER's minimal PATH (/usr/bin:/bin:/usr/sbin:/sbin) — which lacks
+  # the nix-installed tmux. Without the prepend, every internal `tmux` call is a
+  # 127 "command not found", and that 127 propagates out of `tmux new-session`
+  # (tripping `set -o errexit` in callers such as the continuity resume script).
+  tmuxLoggingToggle = "PATH=${pkgs.tmux}/bin:\$PATH ${pkgs.tmuxPlugins.logging}/share/tmux-plugins/logging/scripts/toggle_logging.sh";
 in
 {
   programs.tmux = {


### PR DESCRIPTION
## Summary

Two related fixes to tmux automatic session logging (the tmux-logging plugin
auto-start path):

1. **Log paths** — move the tmux-autostart launchd logs from `/tmp` to
   `~/Library/Logs` so they survive a reboot's `/tmp` wipe.
2. **PATH in run-shell hooks** — the plugin scripts shell out to bare `tmux`,
   but a `run-shell` hook inherits the tmux *server's* minimal PATH
   (`/usr/bin:/bin:/usr/sbin:/sbin`), which lacks the nix-installed tmux. Every
   internal `tmux` call returned 127, and that status propagated out of
   `tmux new-session`, tripping `set -o errexit` in callers such as the
   claude-continuity resume script (which aborted before consuming its arm
   marker even though the session launched). Fix prepends `${pkgs.tmux}/bin`
   to PATH in the shared toggle command so all three `after-*` hooks resolve
   tmux.

## Verification

- `nix fmt`, `statix check`, `deadnix --fail` clean on `tmux.nix`.
- Rendered hook string verified via `nix eval`: literal `$PATH` preserved,
  tmux store path matches the running server (`tmux-3.6a`).
- Reproduced the 127 in a `tmux run-shell` context and confirmed the PATH
  prepend returns rc=0.
- Full `nix flake check` runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)