### PR TITLE
chore: remove shellcheck everywhere

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ Cross-platform home-manager modules for development environment tools.
 ## Build Validation
 
 ```bash
-nix flake check    # Runs formatting, statix, deadnix, shellcheck checks
+nix flake check    # Runs formatting, statix, deadnix checks
 nix fmt            # Fix formatting
 ```
 
@@ -23,7 +23,7 @@ nix fmt            # Fix formatting
 - User shell config (zsh, git, direnv)
 - Editor settings (VS Code, Vim config)
 - CLI dev tools (bat, ripgrep, jq, fzf, etc.)
-- Linters and formatters (shellcheck, statix, deadnix)
+- Linters and formatters (statix, deadnix)
 - Programming languages (Python, Bun)
 - Security tools (password manager CLIs, aws-vault)
 - macOS user-level LaunchAgents (under `modules/home-manager/darwin/`)

--- a/flake.nix
+++ b/flake.nix
@@ -76,7 +76,7 @@
       #
       # Scoped to x86_64-linux only so `nix flake check --all-systems` succeeds
       # from a single linux runner. All checks here are either source-only
-      # (formatting, statix, deadnix, shellcheck — identical source across
+      # (formatting, statix, deadnix — identical source across
       # systems) or wrap evaluation in a writeText (module-eval), so running
       # them once is sufficient and produces a derivation buildable on the
       # runner. Other systems intentionally have no `checks` entries.

--- a/lib/checks.nix
+++ b/lib/checks.nix
@@ -42,31 +42,6 @@
     touch $out
   '';
 
-  # Lint shell scripts with shellcheck
-  # Catches common bugs: unquoted variables, undefined vars, useless use of cat, etc.
-  # Excludes .git directories and nix store paths
-  # --severity=warning: Only fail on warning/error level (not info style suggestions)
-  # SC1091: Exclude "not following" errors for external sources (can't resolve in Nix sandbox)
-  # Excludes zsh scripts (shellcheck only supports sh/bash/dash/ksh)
-  # Uses find with -print0 and xargs -0 for robustness with filenames containing spaces and special characters
-  # TODO: Fix info-level issues (SC2086 quoting) in shell scripts for stricter checking
-  shellcheck = pkgs.runCommand "check-shellcheck" { } ''
-    cd ${src}
-    find . -name "*.sh" -not -path "./.git/*" -not -path "./result/*" -print0 | \
-    xargs -0 bash -c '
-      for script in "$@"; do
-        # Skip zsh scripts (shellcheck does not support them)
-        if head -1 "$script" | grep -q "zsh"; then
-          echo "Skipping zsh script: $script"
-        else
-          echo "Checking $script..."
-          ${pkgs.lib.getExe pkgs.shellcheck} --severity=warning --exclude=SC1091 "$script"
-        fi
-      done
-    ' bash
-    touch $out
-  '';
-
   # Verify the home-manager module evaluates without errors
   # Catches: broken imports, missing args, type errors, assertion failures
   # Note: uses unsafeDiscardStringContext — forces eval without building packages absent from binary cache.

--- a/modules/common/packages/core.nix
+++ b/modules/common/packages/core.nix
@@ -66,7 +66,6 @@ with pkgs;
   # pre-commit hooks and should be available on any development machine.
 
   # Shell
-  shellcheck # Shell script static analysis (POSIX, bash)
   shfmt # Shell script formatter
 
   # Documentation


### PR DESCRIPTION
Per maintainer decision, shellcheck is no longer used anywhere — it is more
trouble than it is worth for AI-driven edits.

- Drop the `shellcheck` flake check from `lib/checks.nix`.
- Remove `shellcheck` from the installed dev packages (`core.nix`).
- Clear references in `flake.nix` and `AGENTS.md`.

Remaining checks: formatting, statix, deadnix, module-eval.

Verified: `nix eval .#checks.x86_64-linux` → `[deadnix, formatting, module-eval, statix]`; nixfmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)