### PR TITLE
feat(aws): serve tf-proxmox creds via OpenBao credential_process

### DIFF
--- a/modules/home-manager/aws/config.nix
+++ b/modules/home-manager/aws/config.nix
@@ -67,9 +67,10 @@ let
   # secrets engine (dynamic STS, assumed_role). A project listed here gets a
   # `credential_process` profile instead of source_profile/role_arn — the
   # wrapper (nix-darwin `openbao-aws-creds`, on PATH system-wide) reads the
-  # terraform-apply AppRole from openbao.keychain-db and mints short-lived
-  # creds on demand, so no static AWS key exists on the machine. Move a
-  # project here once its aws/roles/<name> exists in OpenBao.
+  # terraform-apply AppRole secret-zero from the ambient environment (injected
+  # by running terragrunt under `doppler run`) and mints short-lived creds on
+  # demand, so no static AWS key exists on the machine. Move a project here
+  # once its aws/roles/<name> exists in OpenBao.
   openbaoStsProjects = {
     proxmox = "openbao-aws-creds tf-proxmox";
   };


### PR DESCRIPTION
Wires the `tf-proxmox` AWS profile to an OpenBao-backed `credential_process`
instead of a static aws-vault base key. `openbaoStsProjects` maps a project to
the `openbao-aws-creds` wrapper (shipped by nix-darwin); `generateProfile`
emits a `credential_process` line for those projects and the existing
`source_profile`/`role_arn` for the rest.

Secret-zero (the AppRole `role_id`/`secret_id` + `VAULT_ADDR`) is sourced from
the ambient environment injected by running terragrunt under `doppler run` —
no local keychain, matching the reconciled design in nix-darwin #1686.

This is the local / break-glass path; routine applies run on Terrakube remote
execution against the same server-side AWS secrets engine.