### PR TITLE
feat(aws): add openbao-iac-admin credential_process profile

### DIFF
--- a/modules/home-manager/aws/config.nix
+++ b/modules/home-manager/aws/config.nix
@@ -96,7 +96,21 @@ let
   tfProfiles =
     (mkTfProfiles "terraform" tfProjects.terraform) ++ (mkTfProfiles "tofu" tfProjects.tofu);
 
-  profiles = baseProfiles ++ tfProfiles;
+  # OpenBao-brokered broad IaC/admin identity: dynamic STS (assumed_role) for
+  # role/openbao-iac-admin, minted on demand by the `openbao-aws-creds` wrapper
+  # (same credential_process path as the tf-* OpenBao profiles). Not tied to a
+  # single tf project — this is the general "reach any AWS API via OpenBao"
+  # identity; its breadth is capped by a permissions boundary on the AWS role
+  # itself, so no static key ever lives on the machine.
+  openbaoAdminProfiles = [
+    {
+      name = "openbao-iac-admin";
+      comment = "openbao-iac-admin: dynamic STS creds from OpenBao (credential_process, no static key)";
+      credential_process = "openbao-aws-creds openbao-iac-admin";
+    }
+  ];
+
+  profiles = baseProfiles ++ openbaoAdminProfiles ++ tfProfiles;
 
   generateProfile =
     profile:


### PR DESCRIPTION
## What

Adds a standalone `[profile openbao-iac-admin]` to the generated `~/.aws/config`:

```ini
[profile openbao-iac-admin]
region = us-east-2
output = json
credential_process = openbao-aws-creds openbao-iac-admin
```

## Why

This is the general OpenBao-brokered IaC/admin identity: the `openbao-aws-creds` wrapper mints short-lived STS creds (assumed_role) on demand, so agents and humans can reach any AWS API through OpenBao with **no static key on the machine**. Breadth is capped by a permissions boundary on the AWS role itself. Mirrors the existing `tf-*` credential_process pattern but is not tied to a single tf project.

The AWS role, its permissions boundary, and the OpenBao `aws/roles/openbao-iac-admin` broker were provisioned separately; this only wires the local profile.

## Verification

- `nix` evaluates the profile list (pure attrset concat).
- After merge + rebuild: `aws --profile openbao-iac-admin sts get-caller-identity` resolves to the assumed `openbao-iac-admin` role.