### PR TITLE
chore(docs): drop unnecessary braces from $GIT_HOME_PUBLIC ref

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,7 +85,7 @@ From nix-darwin, test changes with:
 
 ```bash
 sudo darwin-rebuild switch --flake . \
-  --override-input nix-home ${GIT_HOME_PUBLIC}/nix-home/main
+  --override-input nix-home $GIT_HOME_PUBLIC/nix-home/main
 ```
 
 ## Tooling baseline (inherited from dryvist/.github)


### PR DESCRIPTION
Bare `$GIT_HOME_PUBLIC` is valid standard bash here — the next character is a path separator, so the variable name terminates on its own and the braces add nothing.

Braces are kept wherever removing them would change meaning (`${VAR}_suffix`, `${VAR:-default}`, `${#VAR}`); this repo had no such case.

Part of a workspace-wide convention cleanup; the canonical `~/git/AGENTS.md` path-variable table has been updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)